### PR TITLE
fix: resolve ZCC legacy credential loading bugs

### DIFF
--- a/zscaler_mcp/client.py
+++ b/zscaler_mcp/client.py
@@ -96,9 +96,8 @@ def get_zscaler_client(
         password = password if password not in [None, ""] else os.getenv("ZTW_PASSWORD")
         api_key = api_key if api_key not in [None, ""] else os.getenv("ZTW_API_KEY")
 
-        # ZCC legacy credentials
-        api_key = api_key if api_key not in [None, ""] else os.getenv("ZCC_CLIENT_ID")
-        secret_key = secret_key if secret_key not in [None, ""] else os.getenv("ZCC_CLIENT_ID")
+        # ZCC legacy credentials — resolved in the service block below
+        # to avoid ZIA/ZTW api_key overwriting ZCC_CLIENT_ID
 
         # ZDX legacy credentials
         key_id = key_id if key_id not in [None, ""] else os.getenv("ZDX_CLIENT_ID")
@@ -197,6 +196,8 @@ def get_zscaler_client(
             return LegacyZPAClient(config)
 
         elif service == "zcc":
+            api_key = os.getenv("ZCC_CLIENT_ID", api_key)
+            secret_key = os.getenv("ZCC_CLIENT_SECRET", secret_key)
             if not all([api_key, secret_key, cloud]):
                 raise ValueError("Missing required credentials for LegacyZCCClient.")
             config = {


### PR DESCRIPTION
## Summary

Two bugs in `get_zscaler_client()` prevented `LegacyZCCClient` from authenticating when ZIA credentials were also configured:

1. **Wrong env var for secret_key** (line 101): `ZCC_CLIENT_ID` was read instead of `ZCC_CLIENT_SECRET`
2. **Shared variable collision** (line 92→100): `api_key` was already set by `ZIA_API_KEY` before reaching the ZCC fallback, so `ZCC_CLIENT_ID` was never loaded

### Root Cause

All legacy credentials are loaded sequentially into shared variables. When both ZIA and ZCC are configured, `api_key` gets set to `ZIA_API_KEY` first (line 92), and the ZCC fallback on line 100 is a no-op since `api_key` is already non-empty.

### Fix

Move ZCC credential resolution into the service-specific block (where `service == "zcc"`) so it can properly override the shared variables:

```python
elif service == "zcc":
    api_key = os.getenv("ZCC_CLIENT_ID", api_key)
    secret_key = os.getenv("ZCC_CLIENT_SECRET", secret_key)
```

### Testing

Verified against a live `zscalerthree` tenant with both ZIA and ZCC credentials configured via environment variables. Before the fix, `zcc_list_devices` always failed with "Failed to login using provided credentials." After the fix, authentication succeeds and device data is returned.