### PR TITLE
Remove unsupported keys from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,5 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "zscaler",
-  "description": "Zscaler cloud security platform plugin for Claude",
   "owner": {
     "name": "Zscaler",
     "email": "devrel@zscaler.com"


### PR DESCRIPTION
## Summary

The `$schema` and `description` fields at the root level of `.claude-plugin/marketplace.json` are not part of the Claude Code marketplace schema. `claude plugin validate` rejects unrecognized keys, which causes the marketplace CI scan to fail during submission.

Removing these two fields allows validation to pass:

```
$ claude plugin validate .
✔ Validation passed with warnings
```

## Context

Your Zscaler plugin submission to the Claude Code marketplace was blocked by this validation failure in the automated CI scan. This fix should unblock the submission pipeline.