### PR TITLE
fix: skip clientless_app_ids in body when None to avoid BROWSER_ACCESS lookup on standard segments

### DIFF
--- a/tests/zpa/test_zpa_tools.py
+++ b/tests/zpa/test_zpa_tools.py
@@ -141,7 +141,7 @@ class TestZpaAppSegments:
     @patch("zscaler_mcp.tools.zpa.app_segments.get_zscaler_client")
     def test_update_application_segment_standard_no_clientless(self, mock_get_client, mock_client):
         """Standard segments must NOT pass clientless_app_ids to the SDK (omit the key entirely).
-        Passing None triggers the SDK's BROWSER_ACCESS lookup which fails for non-BA segments."""
+        Passing None or [] triggers the SDK's BROWSER_ACCESS lookup which fails for non-BA segments."""
         from zscaler_mcp.tools.zpa.app_segments import zpa_update_application_segment
 
         updated = _mock_obj({"id": "seg1", "name": "Updated"})
@@ -154,8 +154,22 @@ class TestZpaAppSegments:
         call_kwargs = mock_client.zpa.application_segment.update_segment.call_args[1]
         assert "clientless_app_ids" not in call_kwargs, (
             "clientless_app_ids must be omitted for standard segments — "
-            "its presence (even as None) triggers broken BROWSER_ACCESS SDK lookup"
+            "its presence (even as None or []) triggers broken BROWSER_ACCESS SDK lookup"
         )
+
+    @patch("zscaler_mcp.tools.zpa.app_segments.get_zscaler_client")
+    def test_update_application_segment_empty_clientless_omitted(self, mock_get_client, mock_client):
+        """Empty list must also be omitted — [] is falsy and should not trigger BROWSER_ACCESS lookup."""
+        from zscaler_mcp.tools.zpa.app_segments import zpa_update_application_segment
+
+        updated = _mock_obj({"id": "seg3", "name": "Updated"})
+        mock_client.zpa.application_segment.update_segment.return_value = (updated, None, None)
+        mock_get_client.return_value = mock_client
+
+        zpa_update_application_segment(segment_id="seg3", clientless_app_ids=[])
+
+        call_kwargs = mock_client.zpa.application_segment.update_segment.call_args[1]
+        assert "clientless_app_ids" not in call_kwargs
 
     @patch("zscaler_mcp.tools.zpa.app_segments.get_zscaler_client")
     def test_update_application_segment_with_clientless_included(self, mock_get_client, mock_client):

--- a/tests/zpa/test_zpa_tools.py
+++ b/tests/zpa/test_zpa_tools.py
@@ -138,6 +138,57 @@ class TestZpaAppSegments:
         zpa_list_application_segments(use_legacy=True)
         mock_get_client.assert_called_once_with(use_legacy=True, service="zpa")
 
+    @patch("zscaler_mcp.tools.zpa.app_segments.get_zscaler_client")
+    def test_update_application_segment_standard_no_clientless(self, mock_get_client, mock_client):
+        """Standard segments must NOT pass clientless_app_ids to the SDK (omit the key entirely).
+        Passing None triggers the SDK's BROWSER_ACCESS lookup which fails for non-BA segments."""
+        from zscaler_mcp.tools.zpa.app_segments import zpa_update_application_segment
+
+        updated = _mock_obj({"id": "seg1", "name": "Updated"})
+        mock_client.zpa.application_segment.update_segment.return_value = (updated, None, None)
+        mock_get_client.return_value = mock_client
+
+        result = zpa_update_application_segment(segment_id="seg1", name="Updated")
+
+        assert result["id"] == "seg1"
+        call_kwargs = mock_client.zpa.application_segment.update_segment.call_args[1]
+        assert "clientless_app_ids" not in call_kwargs, (
+            "clientless_app_ids must be omitted for standard segments — "
+            "its presence (even as None) triggers broken BROWSER_ACCESS SDK lookup"
+        )
+
+    @patch("zscaler_mcp.tools.zpa.app_segments.get_zscaler_client")
+    def test_update_application_segment_with_clientless_included(self, mock_get_client, mock_client):
+        """When clientless_app_ids is explicitly provided it should be forwarded to the SDK."""
+        from zscaler_mcp.tools.zpa.app_segments import zpa_update_application_segment
+
+        updated = _mock_obj({"id": "seg2", "name": "BAApp"})
+        mock_client.zpa.application_segment.update_segment.return_value = (updated, None, None)
+        mock_get_client.return_value = mock_client
+
+        clientless = [{"id": "cl1"}]
+        zpa_update_application_segment(segment_id="seg2", clientless_app_ids=clientless)
+
+        call_kwargs = mock_client.zpa.application_segment.update_segment.call_args[1]
+        assert call_kwargs.get("clientless_app_ids") == clientless
+
+    @patch("zscaler_mcp.tools.zpa.app_segments.get_zscaler_client")
+    def test_create_application_segment_standard_no_clientless(self, mock_get_client, mock_client):
+        """Same guard applies to create — clientless_app_ids must be omitted when not provided."""
+        from zscaler_mcp.tools.zpa.app_segments import zpa_create_application_segment
+
+        created = _mock_obj({"id": "new2", "name": "StdApp"})
+        mock_client.zpa.application_segment.add_segment.return_value = (created, None, None)
+        mock_get_client.return_value = mock_client
+
+        zpa_create_application_segment(
+            name="StdApp", segment_group_id="sg1", domain_names=["std.example.com"],
+            tcp_port_ranges=["443", "443"],
+        )
+
+        call_kwargs = mock_client.zpa.application_segment.add_segment.call_args[1]
+        assert "clientless_app_ids" not in call_kwargs
+
 
 # ============================================================================
 # SEGMENT GROUPS

--- a/zscaler_mcp/tools/zpa/app_segments.py
+++ b/zscaler_mcp/tools/zpa/app_segments.py
@@ -224,7 +224,7 @@ def zpa_create_application_segment(
         "passive_health_enabled": passive_health_enabled,
     }
 
-    if clientless_app_ids is not None:
+    if clientless_app_ids:
         body["clientless_app_ids"] = clientless_app_ids
 
     if tcp_port_range:
@@ -351,7 +351,7 @@ def zpa_update_application_segment(
 
     # Only include clientless_app_ids when explicitly provided — passing None causes the SDK
     # to enter BROWSER_ACCESS lookup logic and fail on standard segments.
-    if clientless_app_ids is not None:
+    if clientless_app_ids:
         body["clientless_app_ids"] = clientless_app_ids
 
     if tcp_port_range:

--- a/zscaler_mcp/tools/zpa/app_segments.py
+++ b/zscaler_mcp/tools/zpa/app_segments.py
@@ -222,8 +222,10 @@ def zpa_create_application_segment(
         "health_reporting": health_reporting,
         "is_cname_enabled": is_cname_enabled,
         "passive_health_enabled": passive_health_enabled,
-        "clientless_app_ids": clientless_app_ids,
     }
+
+    if clientless_app_ids is not None:
+        body["clientless_app_ids"] = clientless_app_ids
 
     if tcp_port_range:
         body["tcp_port_range"] = tcp_port_range
@@ -345,8 +347,12 @@ def zpa_update_application_segment(
         "health_reporting": health_reporting,
         "is_cname_enabled": is_cname_enabled,
         "passive_health_enabled": passive_health_enabled,
-        "clientless_app_ids": clientless_app_ids,
     }
+
+    # Only include clientless_app_ids when explicitly provided — passing None causes the SDK
+    # to enter BROWSER_ACCESS lookup logic and fail on standard segments.
+    if clientless_app_ids is not None:
+        body["clientless_app_ids"] = clientless_app_ids
 
     if tcp_port_range:
         body["tcp_port_range"] = tcp_port_range


### PR DESCRIPTION
## Summary

Fixes #50.

- `zpa_update_application_segment` and `zpa_create_application_segment` both unconditionally included `clientless_app_ids` in the request body, even when `None`
- The Zscaler Python SDK checks for **key presence** (not truthiness), so passing `None` always triggered the `BROWSER_ACCESS` segment lookup
- For standard (non-BA) segments no match is found → every update/create call failed

## Changes

- `zscaler_mcp/tools/zpa/app_segments.py` — conditionally add `clientless_app_ids` to body only when explicitly provided (both `zpa_create_application_segment` and `zpa_update_application_segment`)
- `tests/zpa/test_zpa_tools.py` — three new unit tests:
  - `test_update_application_segment_standard_no_clientless` — key must be absent for standard segments
  - `test_update_application_segment_with_clientless_included` — key forwarded when explicitly provided
  - `test_create_application_segment_standard_no_clientless` — same guard on create path

## Test plan

- [ ] All 70 unit tests pass (`uv run --with pytest python -m pytest tests/zpa/test_zpa_tools.py`)
- [ ] `zpa_update_application_segment` succeeds on a standard ZPA segment without `clientless_app_ids`
- [ ] `zpa_update_application_segment` still works when `clientless_app_ids` is explicitly passed for browser-access segments