### PR TITLE
fix: correct semantic-release asset path + re-trigger skipped v0.13.0 release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -16,7 +16,7 @@
         "assets": [
           "pyproject.toml",
           "README.md",
-          "zscaler_mcp/__init__.py",
+          "src/zscaler_mcp/__init__.py",
           ".claude-plugin/marketplace.json",
           ".claude-plugin/plugin.json",
           ".mcp.json",


### PR DESCRIPTION
## Why

Two related release-pipeline issues surfaced after merging #82:

### 1. The v0.13.0 release never fired
The squash-merge commit for #82 (`4a2d83a`) inherited a `[skip ci]` line in its
**body** from the branch's doc-regeneration commits. GitHub honors `[skip ci]`
anywhere in the commit message, so **all** push-triggered workflows — including
`Release` (semantic-release) — were skipped on `master`. No version was bumped;
latest tag/release remains `v0.12.7`.

### 2. `.releaserc.json` pointed at the pre-v2 package path
`@semantic-release/git` still listed `zscaler_mcp/__init__.py`, but the v2 `src/`
layout moved the package and `set-version.sh` bumps `src/zscaler_mcp/__init__.py`.
The bumped `__init__.py` would never be committed into the `chore(release)` commit.

## What this PR does

- Repoints the semantic-release git asset to `src/zscaler_mcp/__init__.py`.
- Provides a **clean commit** (no `[skip ci]`) whose merge to `master` re-triggers
  the `Release` workflow. semantic-release will analyze commits since `v0.12.7`,
  see the `feat:` from #82, and cut **v0.13.0** (PyPI + GitHub release + tag +
  MCPB bundle + versioned Docker + MCP Registry).

## Merge instructions (important)

When merging, ensure the final commit message contains **no `[skip ci]`**. A
simple **"Create a merge commit"** or **"Rebase and merge"** keeps the head
message clean. If you squash, delete any `[skip ci]` lines from the auto-filled
body before confirming.