### PR TITLE
fix: restore in-process TLS, host-header validation, and --enable-write-tools

### DIFF
--- a/src/zscaler_mcp/security/__init__.py
+++ b/src/zscaler_mcp/security/__init__.py
@@ -36,9 +36,13 @@ from zscaler_mcp.security.entitlements import (
     obtain_oneapi_token,
 )
 from zscaler_mcp.security.hardening import (
+    HostValidationMiddleware,
     SourceIPMiddleware,
     apply_transport_hardening,
+    get_allowed_hosts,
     get_allowed_source_ips,
+    host_validation_disabled,
+    validate_host_binding,
 )
 from zscaler_mcp.security.sanitize import (
     is_sanitization_enabled,
@@ -64,8 +68,12 @@ __all__ = [
     "obtain_oneapi_token",
     # hardening
     "SourceIPMiddleware",
+    "HostValidationMiddleware",
     "apply_transport_hardening",
     "get_allowed_source_ips",
+    "get_allowed_hosts",
+    "host_validation_disabled",
+    "validate_host_binding",
     # elicitation
     "check_confirmation",
     "extract_confirmed_from_kwargs",

--- a/src/zscaler_mcp/security/hardening.py
+++ b/src/zscaler_mcp/security/hardening.py
@@ -109,6 +109,149 @@ class SourceIPMiddleware:
 
 
 # ---------------------------------------------------------------------------
+# Host header validation (DNS-rebinding protection)
+# ---------------------------------------------------------------------------
+
+
+def get_allowed_hosts() -> Optional[list[str]]:
+    """Parse ``ZSCALER_MCP_ALLOWED_HOSTS`` into a list, or ``None``.
+
+    Entries may be exact (``example.com:443``), port-wildcarded
+    (``example.com:*``), bare host (``example.com``), or the ``*`` catch-all.
+    """
+    raw = os.getenv("ZSCALER_MCP_ALLOWED_HOSTS", "").strip()
+    if not raw:
+        return None
+    entries = [e.strip() for e in raw.split(",") if e.strip()]
+    return entries or None
+
+
+def host_validation_disabled() -> bool:
+    """True when ``ZSCALER_MCP_DISABLE_HOST_VALIDATION`` opts out of Host checks."""
+    return os.getenv("ZSCALER_MCP_DISABLE_HOST_VALIDATION", "").strip().lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+
+
+def _split_host_port(value: str) -> tuple[str, str]:
+    """Split a ``host[:port]`` value, leaving IPv6 literals (``[::1]:80``) intact."""
+    value = value.strip().lower()
+    if value.startswith("["):  # bracketed IPv6 literal
+        host, sep, port = value.rpartition("]:")
+        if sep:
+            return host + "]", port
+        return value, ""
+    if value.count(":") == 1:
+        host, _, port = value.rpartition(":")
+        return host, port
+    return value, ""
+
+
+def _host_matches(host_header: str, allowed: list[str]) -> bool:
+    """Match a request ``Host`` header against the configured allowlist.
+
+    Supports ``*`` (any host), ``host:*`` (any port), exact ``host:port``, and
+    bare ``host`` (any port). Empty Host headers are rejected when an allowlist
+    is configured.
+    """
+    host_header = host_header.strip().lower()
+    if not host_header:
+        return False
+    h_host, h_port = _split_host_port(host_header)
+    for entry in allowed:
+        e = entry.strip().lower()
+        if not e:
+            continue
+        if e == "*" or e == host_header:
+            return True
+        e_host, e_port = _split_host_port(e)
+        if ":" in e:
+            if e_port == "*" and e_host == h_host:
+                return True
+            if e_host == h_host and e_port == h_port:
+                return True
+        elif e == h_host:
+            return True
+    return False
+
+
+class HostValidationMiddleware:
+    """ASGI middleware that rejects requests whose ``Host`` header is not allowed.
+
+    Zero-trust DNS-rebinding protection: only active when
+    ``ZSCALER_MCP_ALLOWED_HOSTS`` is configured (and not disabled via
+    ``ZSCALER_MCP_DISABLE_HOST_VALIDATION``). Health-check paths bypass the
+    check so load-balancer probes keep working.
+    """
+
+    SKIP_PATHS = frozenset({"/health", "/healthz", "/ready"})
+
+    def __init__(self, app: Any, allowed_hosts: list[str]):
+        self.app = app
+        self.allowed_hosts = allowed_hosts
+
+    async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        if scope.get("path", "") in self.SKIP_PATHS:
+            await self.app(scope, receive, send)
+            return
+
+        host = ""
+        for name, value in scope.get("headers", []):
+            if name == b"host":
+                try:
+                    host = value.decode("latin-1")
+                except UnicodeDecodeError:
+                    host = ""
+                break
+
+        if not _host_matches(host, self.allowed_hosts):
+            from starlette.responses import JSONResponse
+
+            body = {
+                "jsonrpc": "2.0",
+                "error": {
+                    "code": -32001,
+                    "message": (
+                        f"Misdirected request: Host header '{host}' is not in the "
+                        "allowed list (possible DNS rebinding attempt)"
+                    ),
+                },
+            }
+            # 421 Misdirected Request — the same status the MCP SDK's transport
+            # security returns for a rejected Host.
+            response = JSONResponse(body, status_code=421)
+            await response(scope, receive, send)
+            return
+
+        await self.app(scope, receive, send)
+
+
+def validate_host_binding(host: str) -> None:
+    """Refuse to bind a public interface without explicit Host validation config.
+
+    Mirrors v1: binding to ``0.0.0.0`` requires either an
+    ``ZSCALER_MCP_ALLOWED_HOSTS`` allowlist (recommended) or an explicit
+    ``ZSCALER_MCP_DISABLE_HOST_VALIDATION=true`` opt-out. Anything else exits.
+    """
+    if host != "0.0.0.0":
+        return
+    if host_validation_disabled() or get_allowed_hosts() is not None:
+        return
+    raise SystemExit(
+        "ERROR: Cannot bind to 0.0.0.0 without host validation configuration.\n"
+        "Set one of:\n"
+        "  ZSCALER_MCP_ALLOWED_HOSTS=your-host:*,localhost:*  (recommended)\n"
+        "  ZSCALER_MCP_DISABLE_HOST_VALIDATION=true           (disables protection)\n"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Transport hardening middlewares
 # ---------------------------------------------------------------------------
 
@@ -261,4 +404,27 @@ def apply_transport_hardening(
     if transport == "streamable-http":
         inner = RejectNonSSEGetMiddleware(inner, mcp_path=mcp_path)
     inner = StripTrailingSlashMiddleware(NormalizeContentTypeMiddleware(inner))
+
+    # Host header validation (DNS-rebinding protection). ENABLED by default when
+    # an allowlist is configured; explicitly disable via
+    # ZSCALER_MCP_DISABLE_HOST_VALIDATION=true.
+    if host_validation_disabled():
+        from zscaler_mcp.common.logging import log_security_warning
+
+        log_security_warning(
+            "Host Header Validation is DISABLED",
+            [
+                "The server is vulnerable to DNS rebinding attacks.",
+                "This is NOT recommended for production deployments.",
+                "",
+                "To enable, set ZSCALER_MCP_ALLOWED_HOSTS with your expected hostnames.",
+                "Remove ZSCALER_MCP_DISABLE_HOST_VALIDATION=true to re-enable.",
+            ],
+        )
+    else:
+        allowed_hosts = get_allowed_hosts()
+        if allowed_hosts:
+            logger.info("Host header allowlist active: %s", allowed_hosts)
+            inner = HostValidationMiddleware(inner, allowed_hosts)
+
     return HealthCheckMiddleware(inner, path=health_path)

--- a/src/zscaler_mcp/server.py
+++ b/src/zscaler_mcp/server.py
@@ -44,6 +44,7 @@ from zscaler_mcp.security import (
     apply_transport_hardening,
     get_allowed_source_ips,
     resolve_fastmcp_auth,
+    validate_host_binding,
 )
 
 logger = logging.getLogger("zscaler_mcp")
@@ -155,6 +156,52 @@ def build_server(
 # ---------------------------------------------------------------------------
 
 
+def _tls_kwargs_from_env() -> dict:
+    """Build TLS/SSL kwargs for uvicorn from environment variables (v1 parity).
+
+    Env vars:
+        ZSCALER_MCP_TLS_CERTFILE          - Path to PEM certificate file
+        ZSCALER_MCP_TLS_KEYFILE           - Path to PEM private key file
+        ZSCALER_MCP_TLS_KEYFILE_PASSWORD  - Password for encrypted key (optional)
+        ZSCALER_MCP_TLS_CA_CERTS          - CA bundle for client cert validation (optional)
+
+    Returns an empty dict when TLS is not configured. Raises ``SystemExit`` when
+    the configuration is incomplete or a referenced file is missing.
+    """
+    certfile = os.getenv("ZSCALER_MCP_TLS_CERTFILE", "").strip()
+    keyfile = os.getenv("ZSCALER_MCP_TLS_KEYFILE", "").strip()
+
+    if not certfile and not keyfile:
+        return {}
+
+    if bool(certfile) != bool(keyfile):
+        raise SystemExit(
+            "ERROR: Incomplete TLS configuration.\n"
+            "Both ZSCALER_MCP_TLS_CERTFILE and ZSCALER_MCP_TLS_KEYFILE must be set.\n"
+            f"  ZSCALER_MCP_TLS_CERTFILE = {'(set)' if certfile else '(missing)'}\n"
+            f"  ZSCALER_MCP_TLS_KEYFILE  = {'(set)' if keyfile else '(missing)'}\n"
+        )
+
+    if not os.path.isfile(certfile):
+        raise SystemExit(f"ERROR: TLS certificate file not found: {certfile}")
+    if not os.path.isfile(keyfile):
+        raise SystemExit(f"ERROR: TLS key file not found: {keyfile}")
+
+    tls_kwargs: dict = {"ssl_certfile": certfile, "ssl_keyfile": keyfile}
+
+    password = os.getenv("ZSCALER_MCP_TLS_KEYFILE_PASSWORD", "").strip()
+    if password:
+        tls_kwargs["ssl_keyfile_password"] = password
+
+    ca_certs = os.getenv("ZSCALER_MCP_TLS_CA_CERTS", "").strip()
+    if ca_certs:
+        if not os.path.isfile(ca_certs):
+            raise SystemExit(f"ERROR: TLS CA certificate file not found: {ca_certs}")
+        tls_kwargs["ssl_ca_certs"] = ca_certs
+
+    return tls_kwargs
+
+
 def _run_http(
     server: FastMCP,
     *,
@@ -170,19 +217,30 @@ def _run_http(
     """
     import uvicorn
 
+    # TLS: when certs are configured, uvicorn terminates HTTPS in-process and the
+    # plaintext-HTTP policy is satisfied without ZSCALER_MCP_ALLOW_HTTP.
+    tls_kwargs = _tls_kwargs_from_env()
+    scheme = "https" if tls_kwargs else "http"
+
     allow_http = os.getenv("ZSCALER_MCP_ALLOW_HTTP", "").lower() in ("true", "1", "yes")
-    if host not in ("127.0.0.1", "localhost", "::1") and not allow_http:
+    is_localhost = host in ("127.0.0.1", "localhost", "::1")
+    if not tls_kwargs and not is_localhost and not allow_http:
         log_security_warning(
             "Refusing to bind a non-localhost address over plaintext HTTP",
             [
                 f"The server was asked to listen on {host}:{port} without TLS.",
-                "Set ZSCALER_MCP_ALLOW_HTTP=true to allow plaintext (only if TLS is",
+                "Provide TLS certs (ZSCALER_MCP_TLS_CERTFILE / ZSCALER_MCP_TLS_KEYFILE),",
+                "or set ZSCALER_MCP_ALLOW_HTTP=true to allow plaintext (only if TLS is",
                 "terminated by an overlay/reverse proxy), or bind to 127.0.0.1.",
             ],
         )
         raise SystemExit(
-            "ERROR: plaintext HTTP on a non-localhost bind requires ZSCALER_MCP_ALLOW_HTTP=true"
+            "ERROR: plaintext HTTP on a non-localhost bind requires TLS certs "
+            "or ZSCALER_MCP_ALLOW_HTTP=true"
         )
+
+    # Refuse to bind a public interface without explicit Host validation config.
+    validate_host_binding(host)
 
     fastmcp_transport = "http" if transport == "streamable-http" else "sse"
     app = server.http_app(path=DEFAULT_MCP_PATH, transport=fastmcp_transport)
@@ -196,11 +254,25 @@ def _run_http(
         logger.info("Source IP ACL active: %s", allowed_ips)
         app = SourceIPMiddleware(app, allowed_ips)
 
-    # 3. Transport hardening (outermost: health/slash/content-type/GET-405).
+    # 3. Transport hardening (outermost: health/host-validation/slash/content-type/GET-405).
     app = apply_transport_hardening(app, transport, mcp_path=DEFAULT_MCP_PATH)
 
-    logger.info("Starting %s transport on %s:%d (path=%s)", transport, host, port, DEFAULT_MCP_PATH)
-    uvicorn.run(app, host=host, port=port, log_level="debug" if debug else "info")
+    logger.info(
+        "Starting %s transport on %s://%s:%d (path=%s, tls=%s)",
+        transport,
+        scheme,
+        host,
+        port,
+        DEFAULT_MCP_PATH,
+        "on" if tls_kwargs else "off",
+    )
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_level="debug" if debug else "info",
+        **tls_kwargs,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -476,11 +548,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="Comma-separated toolset ids to enable (default: all).",
     )
     p.add_argument(
+        "--enable-write-tools",
+        action="store_true",
+        default=os.getenv("ZSCALER_MCP_WRITE_ENABLED", "").lower() in ("true", "1", "yes"),
+        help=(
+            "Enable write operations (create/update/delete). Off by default for safety. "
+            "Combine with --write-tools to narrow the allowlist "
+            "(env: ZSCALER_MCP_WRITE_ENABLED)."
+        ),
+    )
+    p.add_argument(
         "--write-tools",
         default=os.getenv("ZSCALER_MCP_WRITE_TOOLS", ""),
         help=(
             "Enable + allowlist write tools (fnmatch patterns, e.g. 'zpa_create_*'). "
-            "Write tools are disabled unless this is set."
+            "Write tools are disabled unless this or --enable-write-tools is set."
         ),
     )
     p.add_argument(
@@ -686,12 +768,11 @@ def main() -> None:
     # stdio must log to stderr so stdout stays a clean JSON-RPC stream.
     configure_logging(debug=args.debug, name="zscaler_mcp", use_stderr=(args.transport == "stdio"))
 
-    # Write tools are enabled when an allowlist is given OR
-    # ZSCALER_MCP_WRITE_ENABLED=true (parity with v1's two-knob model).
+    # Write tools are enabled when an allowlist is given, --enable-write-tools is
+    # passed, OR ZSCALER_MCP_WRITE_ENABLED=true (parity with v1's two-knob model:
+    # --enable-write-tools flips the master switch; --write-tools narrows scope).
     write_allowlist = _parse_csv(args.write_tools)
-    write_enabled = write_allowlist is not None or os.getenv(
-        "ZSCALER_MCP_WRITE_ENABLED", ""
-    ).lower() in ("true", "1", "yes")
+    write_enabled = write_allowlist is not None or args.enable_write_tools
 
     # oidcproxy env-var mode → build a fastmcp auth provider FastMCP wires
     # natively. Every other mode returns None (handled by AuthMiddleware at the

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,6 +52,20 @@ def test_parser_list_tools_flag():
     assert args.list_tools is True
 
 
+def test_parser_enable_write_tools_flag():
+    args = server.build_parser().parse_args(["--enable-write-tools"])
+    assert args.enable_write_tools is True
+    # Default is off for safety (assuming the env var is not set in CI).
+    default = server.build_parser().parse_args([])
+    assert default.enable_write_tools is False
+
+
+def test_enable_write_tools_env_default(monkeypatch):
+    monkeypatch.setenv("ZSCALER_MCP_WRITE_ENABLED", "true")
+    args = server.build_parser().parse_args([])
+    assert args.enable_write_tools is True
+
+
 @pytest.mark.parametrize("value,expected", [([], "basic"), (["bearer"], "bearer")])
 def test_parser_generate_auth_token(value, expected):
     args = server.build_parser().parse_args(["--generate-auth-token", *value])
@@ -165,3 +179,60 @@ def test_user_agent_comment_appended():
 def test_user_agent_no_comment_is_base():
     assert get_combined_user_agent(None) == get_mcp_user_agent()
     assert get_combined_user_agent("  ") == get_mcp_user_agent()
+
+
+# ---------------------------------------------------------------------------
+# TLS config (ZSCALER_MCP_TLS_CERTFILE / KEYFILE / PASSWORD / CA_CERTS)
+# ---------------------------------------------------------------------------
+
+
+def _clear_tls_env(monkeypatch):
+    for var in (
+        "ZSCALER_MCP_TLS_CERTFILE",
+        "ZSCALER_MCP_TLS_KEYFILE",
+        "ZSCALER_MCP_TLS_KEYFILE_PASSWORD",
+        "ZSCALER_MCP_TLS_CA_CERTS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_tls_kwargs_empty_when_unset(monkeypatch):
+    _clear_tls_env(monkeypatch)
+    assert server._tls_kwargs_from_env() == {}
+
+
+def test_tls_kwargs_incomplete_config_raises(monkeypatch):
+    _clear_tls_env(monkeypatch)
+    monkeypatch.setenv("ZSCALER_MCP_TLS_CERTFILE", "/tmp/cert.pem")
+    with pytest.raises(SystemExit) as exc:
+        server._tls_kwargs_from_env()
+    assert "Incomplete TLS" in str(exc.value)
+
+
+def test_tls_kwargs_missing_file_raises(monkeypatch, tmp_path):
+    _clear_tls_env(monkeypatch)
+    monkeypatch.setenv("ZSCALER_MCP_TLS_CERTFILE", str(tmp_path / "nope-cert.pem"))
+    monkeypatch.setenv("ZSCALER_MCP_TLS_KEYFILE", str(tmp_path / "nope-key.pem"))
+    with pytest.raises(SystemExit) as exc:
+        server._tls_kwargs_from_env()
+    assert "not found" in str(exc.value)
+
+
+def test_tls_kwargs_full_config(monkeypatch, tmp_path):
+    _clear_tls_env(monkeypatch)
+    cert = tmp_path / "cert.pem"
+    key = tmp_path / "key.pem"
+    ca = tmp_path / "ca.pem"
+    for f in (cert, key, ca):
+        f.write_text("x")
+    monkeypatch.setenv("ZSCALER_MCP_TLS_CERTFILE", str(cert))
+    monkeypatch.setenv("ZSCALER_MCP_TLS_KEYFILE", str(key))
+    monkeypatch.setenv("ZSCALER_MCP_TLS_KEYFILE_PASSWORD", "pw")
+    monkeypatch.setenv("ZSCALER_MCP_TLS_CA_CERTS", str(ca))
+    kwargs = server._tls_kwargs_from_env()
+    assert kwargs == {
+        "ssl_certfile": str(cert),
+        "ssl_keyfile": str(key),
+        "ssl_keyfile_password": "pw",
+        "ssl_ca_certs": str(ca),
+    }

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -146,3 +146,127 @@ async def test_reject_non_sse_get_passes_sse_accept():
 def test_apply_transport_hardening_noop_for_stdio():
     sentinel = object()
     assert h.apply_transport_hardening(sentinel, "stdio") is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Host header validation (DNS-rebinding protection)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host_header,allowed,expected",
+    [
+        ("example.com:443", ["example.com:*"], True),
+        ("example.com:8000", ["example.com:443"], False),
+        ("example.com:443", ["example.com:443"], True),
+        ("localhost:9000", ["localhost:*", "example.com:443"], True),
+        ("evil.com", ["example.com:*"], False),
+        ("anything:1", ["*"], True),
+        ("", ["example.com:*"], False),
+        ("example.com", ["example.com"], True),
+        ("example.com:80", ["example.com"], True),  # bare host matches any port
+        ("EXAMPLE.com:443", ["example.com:*"], True),  # case-insensitive
+    ],
+)
+def test_host_matches(host_header, allowed, expected):
+    assert h._host_matches(host_header, allowed) is expected
+
+
+def test_get_allowed_hosts(monkeypatch):
+    monkeypatch.delenv("ZSCALER_MCP_ALLOWED_HOSTS", raising=False)
+    assert h.get_allowed_hosts() is None
+    monkeypatch.setenv("ZSCALER_MCP_ALLOWED_HOSTS", "example.com:*, localhost:8000")
+    assert h.get_allowed_hosts() == ["example.com:*", "localhost:8000"]
+
+
+def test_host_validation_disabled(monkeypatch):
+    monkeypatch.delenv("ZSCALER_MCP_DISABLE_HOST_VALIDATION", raising=False)
+    assert h.host_validation_disabled() is False
+    monkeypatch.setenv("ZSCALER_MCP_DISABLE_HOST_VALIDATION", "true")
+    assert h.host_validation_disabled() is True
+
+
+@pytest.mark.asyncio
+async def test_host_validation_blocks_disallowed():
+    mw = h.HostValidationMiddleware(None, ["example.com:*"])
+    scope = {"type": "http", "path": "/mcp", "headers": [(b"host", b"evil.com")]}
+    called, sent = await _drive(mw, scope)
+    assert called is False
+    assert sent[0]["status"] == 421
+
+
+@pytest.mark.asyncio
+async def test_host_validation_allows_allowed():
+    mw = h.HostValidationMiddleware(None, ["example.com:*"])
+    scope = {"type": "http", "path": "/mcp", "headers": [(b"host", b"example.com:443")]}
+    called, _ = await _drive(mw, scope)
+    assert called is True
+
+
+@pytest.mark.asyncio
+async def test_host_validation_health_exempt():
+    mw = h.HostValidationMiddleware(None, ["example.com:*"])
+    scope = {"type": "http", "path": "/health", "headers": [(b"host", b"evil.com")]}
+    called, _ = await _drive(mw, scope)
+    assert called is True
+
+
+def test_validate_host_binding_localhost_noop(monkeypatch):
+    monkeypatch.delenv("ZSCALER_MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("ZSCALER_MCP_DISABLE_HOST_VALIDATION", raising=False)
+    h.validate_host_binding("127.0.0.1")  # no raise
+
+
+def test_validate_host_binding_public_requires_config(monkeypatch):
+    monkeypatch.delenv("ZSCALER_MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("ZSCALER_MCP_DISABLE_HOST_VALIDATION", raising=False)
+    with pytest.raises(SystemExit):
+        h.validate_host_binding("0.0.0.0")
+
+
+def test_validate_host_binding_allowlist_ok(monkeypatch):
+    monkeypatch.setenv("ZSCALER_MCP_ALLOWED_HOSTS", "example.com:*")
+    monkeypatch.delenv("ZSCALER_MCP_DISABLE_HOST_VALIDATION", raising=False)
+    h.validate_host_binding("0.0.0.0")  # no raise
+
+
+def test_validate_host_binding_disable_ok(monkeypatch):
+    monkeypatch.delenv("ZSCALER_MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.setenv("ZSCALER_MCP_DISABLE_HOST_VALIDATION", "true")
+    h.validate_host_binding("0.0.0.0")  # no raise
+
+
+def test_hardening_wires_host_validation_when_allowlist_set(monkeypatch):
+    monkeypatch.setenv("ZSCALER_MCP_ALLOWED_HOSTS", "example.com:*")
+    monkeypatch.delenv("ZSCALER_MCP_DISABLE_HOST_VALIDATION", raising=False)
+
+    async def app(s, r, sd):  # pragma: no cover - not driven here
+        return None
+
+    wrapped = h.apply_transport_hardening(app, "streamable-http")
+    node = wrapped
+    found = False
+    for _ in range(10):
+        if isinstance(node, h.HostValidationMiddleware):
+            found = True
+            break
+        node = getattr(node, "app", None)
+        if node is None:
+            break
+    assert found
+
+
+def test_hardening_no_host_validation_when_unset(monkeypatch):
+    monkeypatch.delenv("ZSCALER_MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("ZSCALER_MCP_DISABLE_HOST_VALIDATION", raising=False)
+
+    async def app(s, r, sd):  # pragma: no cover - not driven here
+        return None
+
+    wrapped = h.apply_transport_hardening(app, "streamable-http")
+    node = wrapped
+    for _ in range(10):
+        assert not isinstance(node, h.HostValidationMiddleware)
+        node = getattr(node, "app", None)
+        if node is None:
+            break


### PR DESCRIPTION
## Summary

The v2 rewrite (migration to `fastmcp` 3.x) inadvertently dropped three v1 operator-facing security knobs during the transport/app-wiring rewrite. `fastmcp` 3.x's `FastMCP()`/`http_app()` no longer accept the low-level MCP SDK's `transport_security=`, and the v2 `_run_http()` path was written without TLS kwargs or a write master-switch. This PR restores all three at **full v1 parity**, implemented natively so they don't depend on removed SDK internals.

- **`--enable-write-tools`** — master switch for write operations (env: `ZSCALER_MCP_WRITE_ENABLED`), off by default. `--write-tools` still narrows the allowlist.
- **In-process TLS** — `ZSCALER_MCP_TLS_CERTFILE` / `_KEYFILE` / `_KEYFILE_PASSWORD` / `_CA_CERTS`, validated and passed to uvicorn. Satisfies the plaintext-HTTP policy without `ZSCALER_MCP_ALLOW_HTTP` when set; logs `https` scheme.
- **Host-header validation (DNS-rebinding protection)** — `ZSCALER_MCP_ALLOWED_HOSTS` + `ZSCALER_MCP_DISABLE_HOST_VALIDATION`, as a native ASGI `HostValidationMiddleware` (421 on mismatch, health paths exempt, `host:*` / exact / bare-host matching), plus a `0.0.0.0`-bind guard that refuses to start without explicit host config.

## Changes

- `src/zscaler_mcp/security/hardening.py` — `HostValidationMiddleware`, `get_allowed_hosts()`, `host_validation_disabled()`, `_host_matches()`, `validate_host_binding()`, wired into `apply_transport_hardening()`.
- `src/zscaler_mcp/security/__init__.py` — export the new host-validation surface.
- `src/zscaler_mcp/server.py` — `_tls_kwargs_from_env()`, TLS + host-binding wiring in `_run_http()`, `--enable-write-tools` flag folded into the write-enable computation.
- `tests/test_hardening.py`, `tests/test_cli.py` — regression tests for host matching/middleware/binding guard, TLS config helper, and the write-enable flag.

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check` on touched files — clean
- [x] `pytest tests/ --ignore=tests/e2e` — 450 passed
- [x] Smoke-tested flag parsing, TLS kwarg construction (empty/incomplete/missing-file/full), host matching, and the `0.0.0.0` binding guard