### PR TITLE
fix(zcc): restore policy name in device summaries

### DIFF
--- a/src/zscaler_mcp/tools/zcc/list_devices.py
+++ b/src/zscaler_mcp/tools/zcc/list_devices.py
@@ -55,6 +55,9 @@ class DeviceSummary(AgentView):
     registration_state: Optional[str] = Field(
         default=None, description="Enrollment/registration state (decision-bearing)."
     )
+    policy_name: Optional[str] = Field(
+        default=None, description="Policy assigned to this enrolled device."
+    )
 
 
 def _shape_device(raw: dict[str, Any]) -> DeviceSummary:
@@ -65,6 +68,7 @@ def _shape_device(raw: dict[str, Any]) -> DeviceSummary:
         os_version=pick(raw, "os_version", "osVersion"),
         agent_version=pick(raw, "agent_version", "agentVersion"),
         registration_state=pick(raw, "registration_state", "registrationState"),
+        policy_name=pick(raw, "policy_name", "policyName"),
     )
 
 
@@ -84,9 +88,10 @@ def _shape_device(raw: dict[str, Any]) -> DeviceSummary:
 def zcc_list_devices(args: ListDevicesInput) -> list[dict[str, Any]]:
     """List ZCC enrolled devices as curated, agent-facing views.
 
-    Read-only. Returns the identifying + state fields (udid, user, hostname,
-    OS, agent version, registration state) rather than the full ~40-field SDK
-    enrollment record. Use the returned `udid` with `zcc_get_device_otp`.
+    Read-only. Returns the identifying + decision-bearing fields (udid, user,
+    hostname, OS, agent version, registration state, assigned policy) rather
+    than the full ~40-field SDK enrollment record. Use the returned `udid`
+    with `zcc_get_device_otp`.
     """
     client = get_zscaler_client(service="zcc")
 

--- a/tests/test_existing_services_shaping.py
+++ b/tests/test_existing_services_shaping.py
@@ -43,6 +43,7 @@ def test_zcc_device_curates_and_keeps_udid():
         "osVersion": "macOS 14",
         "agentVersion": "4.2",
         "registrationState": "REGISTERED",
+        "policyName": "Contractors",
         "policyBlob": {"x": 1},
     }
     view = _shape_device(raw)
@@ -50,7 +51,12 @@ def test_zcc_device_curates_and_keeps_udid():
     d = view.model_dump()
     assert d["udid"] == "d-29-9b"
     assert d["registration_state"] == "REGISTERED"
+    assert d["policy_name"] == "Contractors"
     assert "policyBlob" not in d
+
+
+def test_zcc_device_policy_name_accepts_sdk_snake_case():
+    assert _shape_device({"udid": "d-1", "policy_name": "Employees"}).policy_name == "Employees"
 
 
 def test_zcc_profile_and_network_shape():


### PR DESCRIPTION
## Summary

- restore `policy_name` to the curated ZCC device summary
- accept both SDK snake_case and API camelCase response shapes
- document the assigned policy as a decision-bearing device field

## Why

The v0.13 device shaping layer retained enrollment state but dropped the assigned policy. That regression prevents agents from answering basic policy-assignment questions even though the SDK response still provides the field.

## Validation

- `uv run pytest tests/test_existing_services_shaping.py -q` — 11 passed
- `uv run ruff check src/zscaler_mcp/tools/zcc/list_devices.py tests/test_existing_services_shaping.py`

Fixes #88.
