### PR TITLE
fix(entitlements): map observed CLOUD_CONNECTOR / ZIAM / ZINSIGHTS prd values

### DIFF
--- a/src/zscaler_mcp/security/entitlements.py
+++ b/src/zscaler_mcp/security/entitlements.py
@@ -61,13 +61,20 @@ PRD_TO_SERVICE: dict[str, str] = {
     "ZDX": "zdx",
     "ZCC": "zcc",
     "ZTW": "ztw",
+    # ``CLOUD_CONNECTOR`` is the value observed in a live ZIdentity token for
+    # Cloud & Branch Connector; ``ZTW`` above was never emitted by that tenant.
+    "CLOUD_CONNECTOR": "ztw",
     "ZIDENTITY": "zid",
     "ZID": "zid",
     "IDENTITY": "zid",
+    # ``ZIAM`` is the value observed in a live ZIdentity token for ZIdentity itself.
+    "ZIAM": "zid",
     "ZEASM": "zeasm",
     "EASM": "zeasm",
     "ZINS": "zins",
     "INSIGHTS": "zins",
+    # ``ZINSIGHTS`` is the value observed in a live ZIdentity token for Z-Insights.
+    "ZINSIGHTS": "zins",
     "ZMS": "zms",
     # ZCell (Zscaler Cellular). The exact `prd` claim value ZIdentity emits for
     # Cellular is not yet confirmed against a live token; map the likely variants
@@ -104,18 +111,20 @@ def decode_oneapi_token(token: str) -> Optional[dict]:
         return None
 
 
-def extract_entitled_services(payload: dict) -> Set[str]:
-    """Return the set of internal service codes the token is entitled to.
+def _partition_prd_values(payload: dict) -> Tuple[Set[str], list[str]]:
+    """Split the token's ``prd`` claims into mapped services and unmapped values.
 
-    Reads ``service-info`` from the payload, lifts each ``prd`` value, and maps
-    known product codes to internal service identifiers (``zia`` / ``zpa`` /
-    ...). Unknown product codes are silently skipped.
+    Returns ``(services, unmapped)``. ``unmapped`` holds the original ``prd``
+    strings that :data:`PRD_TO_SERVICE` has no entry for — de-duplicated and
+    sorted — so a caller can tell an operator *which* products got dropped and
+    whether the cause was a mapping gap rather than a real entitlement gap.
     """
     services: Set[str] = set()
+    unmapped: Set[str] = set()
 
     service_info = payload.get("service-info") or payload.get("serviceInfo")
     if not isinstance(service_info, list):
-        return services
+        return services, []
 
     for entry in service_info:
         if not isinstance(entry, dict):
@@ -123,10 +132,43 @@ def extract_entitled_services(payload: dict) -> Set[str]:
         prd = entry.get("prd")
         if not isinstance(prd, str):
             continue
-        mapped = PRD_TO_SERVICE.get(prd.strip().upper())
+        normalized = prd.strip()
+        if not normalized:
+            continue
+        mapped = PRD_TO_SERVICE.get(normalized.upper())
         if mapped:
             services.add(mapped)
+        else:
+            unmapped.add(normalized)
 
+    return services, sorted(unmapped)
+
+
+def _warn_unmapped_prd(unmapped: list[str]) -> None:
+    """Log a single WARN naming the ``prd`` values that no mapping recognised."""
+    if not unmapped:
+        return
+    logger.warning(
+        "Entitlement filter: %d prd value(s) in the OneAPI token have no "
+        "PRD_TO_SERVICE mapping and were ignored: %s. Tools for these products "
+        "are removed even if the tenant is genuinely entitled to them. If those "
+        "products work for you, this is a mapping gap — re-run with "
+        "--no-entitlement-filter to confirm and please report the values upstream.",
+        len(unmapped),
+        unmapped,
+    )
+
+
+def extract_entitled_services(payload: dict) -> Set[str]:
+    """Return the set of internal service codes the token is entitled to.
+
+    Reads ``service-info`` from the payload, lifts each ``prd`` value, and maps
+    known product codes to internal service identifiers (``zia`` / ``zpa`` /
+    ...). Product codes with no mapping are skipped, but a WARN naming them is
+    emitted first so a mapping gap is never silent.
+    """
+    services, unmapped = _partition_prd_values(payload)
+    _warn_unmapped_prd(unmapped)
     return services
 
 
@@ -228,8 +270,15 @@ def apply_entitlement_filter(
     if payload is None:
         return None, "entitlement filter skipped (token did not decode)"
 
-    entitled_services = extract_entitled_services(payload)
+    entitled_services, unmapped_prd = _partition_prd_values(payload)
+    _warn_unmapped_prd(unmapped_prd)
+
     if not entitled_services:
+        if unmapped_prd:
+            return None, (
+                "entitlement filter skipped (no prd value in the token maps to a known "
+                f"service; unmapped: {unmapped_prd})"
+            )
         return None, "entitlement filter skipped (token had no recognizable service-info entries)"
 
     allowed = (set(available_services) & (entitled_services | _ALWAYS_KEEP_SERVICES)) | (
@@ -242,5 +291,6 @@ def apply_entitlement_filter(
         f"entitlement filter applied: entitled services={sorted(entitled_services)}, "
         f"kept {len(kept)} service(s)"
         + (f", removed {len(removed)} service(s): {removed}" if removed else "")
+        + (f", unmapped prd values ignored: {unmapped_prd}" if unmapped_prd else "")
     )
     return allowed, status

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 
 import pytest
 
@@ -78,6 +79,108 @@ def test_extract_handles_aliases():
 @pytest.mark.parametrize("payload", [{}, {"service-info": "nope"}, {"service-info": [123, "x"]}])
 def test_extract_returns_empty_on_garbage(payload):
     assert extract_entitled_services(payload) == set()
+
+
+# ---------------------------------------------------------------------------
+# Observed `prd` values — pinned against a real ZIdentity token
+# ---------------------------------------------------------------------------
+
+# The exact `service-info[].prd` set emitted by a live ZIdentity tenant entitled
+# to ZIA, ZCC, ZDX, Cloud Connector, ZIdentity and Z-Insights. Every one of these
+# products answered its API successfully with that same bearer token, so all six
+# must survive the filter.
+OBSERVED_PRD_VALUES = ["CLOUD_CONNECTOR", "ZCC", "ZDX", "ZIA", "ZIAM", "ZINSIGHTS"]
+
+
+@pytest.mark.parametrize(
+    ("prd", "service"),
+    [("CLOUD_CONNECTOR", "ztw"), ("ZIAM", "zid"), ("ZINSIGHTS", "zins")],
+)
+def test_observed_prd_aliases_are_mapped(prd, service):
+    assert PRD_TO_SERVICE[prd] == service
+    assert extract_entitled_services({"service-info": [{"prd": prd}]}) == {service}
+
+
+def test_observed_token_maps_every_prd_value():
+    payload = {"service-info": [{"prd": p} for p in OBSERVED_PRD_VALUES]}
+    assert extract_entitled_services(payload) == {"ztw", "zcc", "zdx", "zia", "zid", "zins"}
+
+
+def test_observed_token_does_not_strip_entitled_tools():
+    # Regression: CLOUD_CONNECTOR / ZIAM / ZINSIGHTS were unmapped, so ztw, zid
+    # and zins were downscoped away despite the tenant being entitled to them.
+    token = _make_token({"service-info": [{"prd": p} for p in OBSERVED_PRD_VALUES]})
+    available = {"zia", "zcc", "zdx", "ztw", "zid", "zins", "zpa"}
+    allowed, status = apply_entitlement_filter(available, token_provider=lambda: (token, None))
+
+    assert allowed == {"zia", "zcc", "zdx", "ztw", "zid", "zins"}
+    # ZPA is genuinely absent from the token and must still be removed.
+    assert "zpa" not in allowed
+    assert "removed 1 service" in status
+    assert "unmapped" not in status
+
+
+# ---------------------------------------------------------------------------
+# Unmapped `prd` reporting — a mapping gap must never be silent
+# ---------------------------------------------------------------------------
+
+
+def test_extract_warns_about_unmapped_prd_values(caplog):
+    payload = {"service-info": [{"prd": "ZIA"}, {"prd": "BRAND_NEW_PRODUCT"}]}
+    with caplog.at_level(logging.WARNING, logger="zscaler_mcp.security.entitlements"):
+        assert extract_entitled_services(payload) == {"zia"}
+
+    assert "BRAND_NEW_PRODUCT" in caplog.text
+    assert "no PRD_TO_SERVICE mapping" in caplog.text
+
+
+def test_extract_does_not_warn_when_everything_maps(caplog):
+    payload = {"service-info": [{"prd": "ZIA"}, {"prd": "ZPA"}]}
+    with caplog.at_level(logging.WARNING, logger="zscaler_mcp.security.entitlements"):
+        extract_entitled_services(payload)
+
+    assert caplog.text == ""
+
+
+def test_filter_reports_unmapped_prd_values_in_status():
+    token = _make_token({"service-info": [{"prd": "ZIA"}, {"prd": "BRAND_NEW_PRODUCT"}]})
+    allowed, status = apply_entitlement_filter({"zia", "zpa"}, token_provider=lambda: (token, None))
+
+    assert allowed == {"zia"}
+    assert "unmapped prd values ignored: ['BRAND_NEW_PRODUCT']" in status
+
+
+def test_filter_skip_message_names_unmapped_values():
+    # Nothing in the token maps: the operator must see WHY, not just "no
+    # recognizable service-info entries", which reads like a malformed token.
+    token = _make_token({"service-info": [{"prd": "MYSTERY_ONE"}, {"prd": "MYSTERY_TWO"}]})
+    allowed, status = apply_entitlement_filter({"zia"}, token_provider=lambda: (token, None))
+
+    assert allowed is None
+    assert "unmapped: ['MYSTERY_ONE', 'MYSTERY_TWO']" in status
+
+
+def test_unmapped_values_are_deduplicated_and_sorted():
+    payload = {
+        "service-info": [
+            {"prd": "ZETA_PRODUCT"},
+            {"prd": "ALPHA_PRODUCT"},
+            {"prd": "ZETA_PRODUCT"},
+        ]
+    }
+    _, status = apply_entitlement_filter(
+        {"zia"}, token_provider=lambda: (_make_token(payload), None)
+    )
+    assert "['ALPHA_PRODUCT', 'ZETA_PRODUCT']" in status
+
+
+def test_blank_prd_values_are_neither_mapped_nor_reported():
+    payload = {"service-info": [{"prd": "ZIA"}, {"prd": "   "}]}
+    allowed, status = apply_entitlement_filter(
+        {"zia"}, token_provider=lambda: (_make_token(payload), None)
+    )
+    assert allowed == {"zia"}
+    assert "unmapped" not in status
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

`PRD_TO_SERVICE` in `src/zscaler_mcp/security/entitlements.py` does not contain the
`service-info[].prd` values that ZIdentity actually emits for Cloud & Branch
Connector, ZIdentity and Z-Insights. On our tenant the token carries:

```
['CLOUD_CONNECTOR', 'ZCC', 'ZDX', 'ZIA', 'ZIAM', 'ZINSIGHTS']
```

Only `ZCC` / `ZDX` / `ZIA` map, so `apply_entitlement_filter()` computes
`allowed = {zia, zcc, zdx}` and strips every `ztw_*`, `zid_*` and `zins_*` tool
before registration — even though all three products answer **HTTP 200** on the
very same bearer token. That is a mapping gap, not a correct downscope.

Fixes #95.

### What changed

1. **Three observed aliases added** — `CLOUD_CONNECTOR` → `ztw`, `ZIAM` → `zid`,
   `ZINSIGHTS` → `zins`. The existing `ZTW` / `ZIDENTITY` / `ZINS` keys are kept;
   these are additions, not replacements, since other tenants may well emit those.

2. **Unmapped `prd` values are no longer silent.** Previously an unrecognised
   product was skipped without a trace, and the status line reported only
   `entitled services=[...]` plus a `removed N service(s)` count — which does not
   reveal that the cause was a mapping miss rather than a genuine entitlement gap.
   Now:
   - `extract_entitled_services()` emits a single WARN naming the dropped values.
   - `apply_entitlement_filter()` appends `unmapped prd values ignored: [...]` to
     its status line.
   - The "nothing matched" skip path names the values instead of reporting only
     `no recognizable service-info entries`, which reads like a malformed token.

The mapping/reporting split lives in a new private `_partition_prd_values()`
helper. **The public `extract_entitled_services()` signature is unchanged**, so
this is not a breaking change for any caller.

### Why this is worth reporting loudly

The filter is intentionally non-fatal and self-skips on any failure. While
credentials are missing or wrong it skips and **all** tools register — so
`ztw_*` / `zid_*` / `zins_*` appear to work. The moment an operator fixes their
credentials the tool surface silently *shrinks*. That inversion makes a mapping
gap genuinely hard to diagnose from the operator's side, which is why the WARN
matters as much as the three new keys.

Note that the file already carries a `TODO: pin the canonical value against a
real OneAPI token` for ZCell — the same class of problem. This PR does not touch
the ZCell entries; our tenant is not entitled to ZCell, so we have nothing
observed to pin them against.

## Has your change been tested?

Yes.

**Live tenant verification.** Every product in our token was called against the
real API with the same OneAPI bearer token (server run with
`--no-entitlement-filter` so the affected tools were registered at all):

| `prd` claim | service | call | result |
|---|---|---|---|
| `CLOUD_CONNECTOR` | `ztw` | `ztw_list_admins` | HTTP 200 (empty list — no admins provisioned; token accepted) |
| `ZIAM` | `zid` | `zid_list_users` | HTTP 200, user records returned |
| `ZINSIGHTS` | `zins` | `zins_get_shadow_it_summary` | HTTP 200, summary object (all-zero counters for the window) |
| `ZIA` | `zia` | `zia_get_activation_status` | HTTP 200 `{"status":"ACTIVE"}` |
| `ZCC` | `zcc` | `zcc_list_devices` | HTTP 200, 50 device records |

For `ztw` and `zins` the tenant simply has no data to return; the point is that
those endpoints **accept** the token and answer `200`, so the tools were being
removed from a client that could actually use them.

**Automated tests.** 10 new tests in `tests/test_entitlements.py`:

- the three observed aliases map to the right service codes;
- the full observed `prd` set resolves to all six services;
- a regression test asserting the observed token no longer strips `ztw` / `zid` /
  `zins`, **while still removing `zpa`**, which is genuinely absent from the token
  (the filter must not become a no-op);
- WARN is emitted, and names the value, when a `prd` is unmapped;
- WARN is *not* emitted when everything maps;
- the status line carries the unmapped values;
- the skip message names the unmapped values;
- unmapped values are de-duplicated and sorted;
- blank/whitespace `prd` values are neither mapped nor reported as unmapped.

**Full suite, lint and docs gate** (Python 3.13, `uv`):

```
$ pytest tests/ --ignore=tests/e2e -q
425 passed in 4.11s

$ ruff check . --select I
All checks passed!

$ ruff check .
All checks passed!

$ zscaler-mcp --check-docs
Docs are in sync with the live tool inventory.
```

`ruff format` is also clean on both changed files.

One thing I could **not** verify end-to-end: booting the server *without*
`--no-entitlement-filter` to watch the three tool families survive registration
on a real tenant. That path needs live credentials in an environment I can't run
it from, so the fix is covered by the unit tests plus the per-product API calls
above rather than a full startup run. Worth a maintainer sanity check on a
tenant that emits these `prd` values.

Also flagging, but deliberately **not** fixing here as out of scope: the
committed `uv.lock` pins `zscaler-mcp` at `0.13.3` while
`src/zscaler_mcp/__init__.py` is `0.14.0`, so any local `uv` install rewrites the
lockfile. I reverted that hunk to keep this PR to one concern.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented and stable APIs.

Note on documentation: I grepped `*.md` / `*.rst` for `PRD_TO_SERVICE` and the
`prd` claim values and found no doc that enumerates the mapping, so there is
nothing to update. `--check-docs` confirms the generated regions are in sync.
