### PR TITLE
fix(client): stop reporting tenant/customer IDs as missing OneAPI credentials

### DIFF
--- a/src/zscaler_mcp/client.py
+++ b/src/zscaler_mcp/client.py
@@ -21,17 +21,32 @@ from dotenv import load_dotenv
 logger = logging.getLogger(__name__)
 
 
+def _absent(values: dict[str, str | None]) -> list[str]:
+    """Return the names whose value is missing or blank, in declaration order."""
+    return [name for name, value in values.items() if not (value and value.strip())]
+
+
 def get_zscaler_client(*, service: str | None = None):
     """Return an authenticated OneAPI ``ZscalerClient``.
 
-    Credentials are resolved from the environment (or a ``.env`` file):
+    Configuration is resolved from the environment (or a ``.env`` file).
+
+    OneAPI **credentials** — authenticate the client, required for every product:
 
     - ``ZSCALER_CLIENT_ID``
     - ``ZSCALER_CLIENT_SECRET`` (or ``ZSCALER_PRIVATE_KEY`` for JWT auth)
     - ``ZSCALER_VANITY_DOMAIN``
+
+    **Tenant scope** — not credentials; each selects the tenant for exactly one
+    product, and a missing value says nothing about the health of the OneAPI
+    credentials above:
+
     - ``ZSCALER_CUSTOMER_ID`` (required only when ``service="zpa"``)
     - ``ZCELL_CUSTOMER_ID`` (required only when ``service="zcell"``)
-    - ``ZSCALER_CLOUD`` (optional)
+
+    Optional:
+
+    - ``ZSCALER_CLOUD``
 
     Args:
         service: Optional product hint (``"zpa"``, ``"zia"``, ...). Only used to
@@ -59,17 +74,34 @@ def get_zscaler_client(*, service: str | None = None):
     cloud = os.getenv("ZSCALER_CLOUD")
     user_agent_comment = os.getenv("ZSCALER_MCP_USER_AGENT_COMMENT")
 
-    required = {"ZSCALER_CLIENT_ID": client_id, "ZSCALER_VANITY_DOMAIN": vanity_domain}
+    # OneAPI credentials proper: these authenticate the API client itself and are
+    # required for every product.
+    credentials = {"ZSCALER_CLIENT_ID": client_id, "ZSCALER_VANITY_DOMAIN": vanity_domain}
+    # Tenant scope, which is NOT a credential: these select which tenant a given
+    # product's API is addressed against, and each is required by exactly one
+    # product. Reported separately so a missing one never reads as an auth
+    # failure — OneAPI auth can be perfectly healthy while one of these is unset.
+    tenant_scope: dict[str, str | None] = {}
     if service == "zpa":
-        required["ZSCALER_CUSTOMER_ID"] = customer_id
+        tenant_scope["ZSCALER_CUSTOMER_ID"] = customer_id
     if service == "zcell":
-        required["ZCELL_CUSTOMER_ID"] = zcell_customer_id
+        tenant_scope["ZCELL_CUSTOMER_ID"] = zcell_customer_id
 
-    missing = [name for name, value in required.items() if not (value and value.strip())]
-    if missing:
+    missing_credentials = _absent(credentials)
+    if missing_credentials:
         raise RuntimeError(
             "Zscaler SDK failed to initialize due to missing OneAPI credentials: "
-            f"{missing}. Set them in the environment or .env file."
+            f"{missing_credentials}. Set them in the environment or .env file."
+        )
+
+    missing_scope = _absent(tenant_scope)
+    if missing_scope:
+        raise RuntimeError(
+            f"{', '.join(missing_scope)} is required for {service} tools. It is the "
+            "tenant/customer ID, not a OneAPI credential. Set it in the environment "
+            "or .env file. OneAPI authentication itself is unaffected — if other "
+            f"products answer successfully, your credentials are fine. If this tenant "
+            f"is not entitled to {service}, the value may not exist at all."
         )
     if not client_secret and not private_key:
         raise ValueError(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,213 @@
+"""Tests for the Zscaler SDK client factory's configuration guards.
+
+The factory distinguishes two kinds of missing configuration, and the
+distinction is the point: OneAPI **credentials** authenticate the client and are
+required for every product, whereas ``ZSCALER_CUSTOMER_ID`` / ``ZCELL_CUSTOMER_ID``
+are **tenant scope** required by exactly one product each. Reporting the latter
+as a missing credential sends operators to re-check auth that is already working.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from zscaler_mcp.client import _absent, get_zscaler_client
+
+# The credential set that is valid for every product; individual tests drop or
+# add to a copy of this.
+FULL_CREDENTIALS = {
+    "ZSCALER_CLIENT_ID": "client-id",
+    "ZSCALER_CLIENT_SECRET": "client-secret",
+    "ZSCALER_VANITY_DOMAIN": "example",
+}
+
+# Env vars the factory reads. Cleared before each test so a developer's real
+# .env / shell cannot leak in and mask a missing-value assertion.
+_FACTORY_VARS = (
+    "ZSCALER_CLIENT_ID",
+    "ZSCALER_CLIENT_SECRET",
+    "ZSCALER_PRIVATE_KEY",
+    "ZSCALER_VANITY_DOMAIN",
+    "ZSCALER_CUSTOMER_ID",
+    "ZCELL_CUSTOMER_ID",
+    "ZSCALER_CLOUD",
+    "ZSCALER_MCP_USER_AGENT_COMMENT",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(monkeypatch):
+    """Blank the factory's env surface and neutralise ``load_dotenv``."""
+    for name in _FACTORY_VARS:
+        monkeypatch.delenv(name, raising=False)
+    # The factory calls load_dotenv() first; a real .env on the developer's box
+    # would otherwise repopulate what we just cleared.
+    monkeypatch.setattr("zscaler_mcp.client.load_dotenv", lambda *a, **k: False)
+
+
+def _set(monkeypatch, values: dict[str, str]) -> None:
+    for name, value in values.items():
+        monkeypatch.setenv(name, value)
+
+
+# ---------------------------------------------------------------------------
+# _absent
+# ---------------------------------------------------------------------------
+
+
+def test_absent_reports_missing_and_blank_in_declaration_order():
+    assert _absent({"A": "set", "B": None, "C": "   ", "D": ""}) == ["B", "C", "D"]
+
+
+def test_absent_returns_empty_when_all_present():
+    assert _absent({"A": "x", "B": "y"}) == []
+
+
+# ---------------------------------------------------------------------------
+# Missing OneAPI credentials — still reported as credentials
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dropped", ["ZSCALER_CLIENT_ID", "ZSCALER_VANITY_DOMAIN"])
+def test_missing_credential_is_reported_as_a_credential(monkeypatch, dropped):
+    creds = {k: v for k, v in FULL_CREDENTIALS.items() if k != dropped}
+    _set(monkeypatch, creds)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        get_zscaler_client(service="zia")
+
+    message = str(excinfo.value)
+    assert "missing OneAPI credentials" in message
+    assert dropped in message
+
+
+def test_blank_credential_counts_as_missing(monkeypatch):
+    _set(monkeypatch, {**FULL_CREDENTIALS, "ZSCALER_CLIENT_ID": "   "})
+
+    with pytest.raises(RuntimeError, match="missing OneAPI credentials"):
+        get_zscaler_client(service="zia")
+
+
+def test_credentials_are_checked_before_tenant_scope(monkeypatch):
+    # Both a credential and the ZPA scope are absent. The credential problem is
+    # the more fundamental one and must be what the operator is told about.
+    _set(monkeypatch, {"ZSCALER_CLIENT_SECRET": "client-secret", "ZSCALER_CLIENT_ID": "client-id"})
+
+    with pytest.raises(RuntimeError) as excinfo:
+        get_zscaler_client(service="zpa")
+
+    message = str(excinfo.value)
+    assert "missing OneAPI credentials" in message
+    assert "ZSCALER_VANITY_DOMAIN" in message
+    assert "ZSCALER_CUSTOMER_ID" not in message
+
+
+# ---------------------------------------------------------------------------
+# Missing tenant scope — must NOT be reported as a credential
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("service", "variable"),
+    [("zpa", "ZSCALER_CUSTOMER_ID"), ("zcell", "ZCELL_CUSTOMER_ID")],
+)
+def test_missing_tenant_scope_is_not_called_a_credential(monkeypatch, service, variable):
+    _set(monkeypatch, FULL_CREDENTIALS)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        get_zscaler_client(service=service)
+
+    message = str(excinfo.value)
+    assert variable in message
+    # The regression this test exists for: the tenant ID was reported as a
+    # missing credential, misdirecting operators to re-check working auth.
+    assert "missing OneAPI credentials" not in message
+    assert "tenant/customer ID" in message
+    assert "not a OneAPI credential" in message
+    # Name the product family so the operator knows what is affected...
+    assert service in message
+    # ...and say that a nonexistent value can mean "not entitled", so the
+    # operator isn't left hunting for an ID that may not exist.
+    assert "not entitled" in message
+
+
+@pytest.mark.parametrize(
+    ("service", "variable"),
+    [("zpa", "ZSCALER_CUSTOMER_ID"), ("zcell", "ZCELL_CUSTOMER_ID")],
+)
+def test_blank_tenant_scope_counts_as_missing(monkeypatch, service, variable):
+    _set(monkeypatch, {**FULL_CREDENTIALS, variable: "   "})
+
+    with pytest.raises(RuntimeError) as excinfo:
+        get_zscaler_client(service=service)
+
+    assert variable in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Tenant scope is per-product, not global
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("service", ["zia", "zdx", "zcc", "ztw", "zid", "zins", "zms", None])
+def test_other_services_do_not_require_any_tenant_scope(monkeypatch, service):
+    # Products other than ZPA / ZCell must construct fine with no customer id.
+    # Guards the "reads as OneAPI-wide when it is per-product" half of the bug.
+    _set(monkeypatch, FULL_CREDENTIALS)
+    constructed = {}
+    monkeypatch.setattr(
+        "zscaler.ZscalerClient", lambda config: constructed.setdefault("cfg", config)
+    )
+
+    get_zscaler_client(service=service)
+
+    assert "customerId" not in constructed["cfg"]
+    assert "zcellCustomerId" not in constructed["cfg"]
+
+
+def test_zpa_scope_does_not_satisfy_zcell(monkeypatch):
+    # The two ids are independent; ZPA's must not stand in for ZCell's.
+    _set(monkeypatch, {**FULL_CREDENTIALS, "ZSCALER_CUSTOMER_ID": "zpa-tenant"})
+
+    with pytest.raises(RuntimeError) as excinfo:
+        get_zscaler_client(service="zcell")
+
+    assert "ZCELL_CUSTOMER_ID" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Happy path — the guards don't block a fully-configured call
+# ---------------------------------------------------------------------------
+
+
+def test_zpa_constructs_when_scope_present(monkeypatch):
+    _set(monkeypatch, {**FULL_CREDENTIALS, "ZSCALER_CUSTOMER_ID": "zpa-tenant"})
+    constructed = {}
+    monkeypatch.setattr(
+        "zscaler.ZscalerClient", lambda config: constructed.setdefault("cfg", config)
+    )
+
+    get_zscaler_client(service="zpa")
+
+    assert constructed["cfg"]["customerId"] == "zpa-tenant"
+    assert constructed["cfg"]["clientId"] == "client-id"
+
+
+def test_zcell_constructs_when_scope_present(monkeypatch):
+    _set(monkeypatch, {**FULL_CREDENTIALS, "ZCELL_CUSTOMER_ID": "zcell-tenant"})
+    constructed = {}
+    monkeypatch.setattr(
+        "zscaler.ZscalerClient", lambda config: constructed.setdefault("cfg", config)
+    )
+
+    get_zscaler_client(service="zcell")
+
+    assert constructed["cfg"]["zcellCustomerId"] == "zcell-tenant"
+
+
+def test_missing_secret_and_private_key_still_raises_value_error(monkeypatch):
+    # Unchanged behaviour: the secret/key check is separate and stays a ValueError.
+    _set(monkeypatch, {k: v for k, v in FULL_CREDENTIALS.items() if k != "ZSCALER_CLIENT_SECRET"})
+
+    with pytest.raises(ValueError, match="ZSCALER_CLIENT_SECRET or ZSCALER_PRIVATE_KEY"):
+        get_zscaler_client(service="zia")


### PR DESCRIPTION
## Description

`get_zscaler_client()` reports a missing **tenant-scope identifier** as a missing
**credential**. When `ZSCALER_CUSTOMER_ID` (ZPA) or `ZCELL_CUSTOMER_ID` (ZCell)
is unset, every tool in that product family fails with:

```
Zscaler SDK failed to initialize due to missing OneAPI credentials: ['ZSCALER_CUSTOMER_ID']. Set them in the environment or .env file.
```

A customer ID is not a credential — it is a tenant scope. Calling it one sends the
operator to re-check their client id / secret / vanity domain, which are fine.
OneAPI auth can be perfectly healthy while one of these is unset: in the case that
prompted this, ZIA, ZCC, ZTW, ZIdentity and Z-Insights all returned HTTP 200 with
the very same environment in the very same session. The wording also implies an
OneAPI-wide failure when the requirement is strictly per-product —
`ZSCALER_CUSTOMER_ID` is only added to `required` when `service == "zpa"`.

Fixes #98.

### What changed

`src/zscaler_mcp/client.py` splits one `required` map into two, checked in order:

1. **Credentials** (`ZSCALER_CLIENT_ID`, `ZSCALER_VANITY_DOMAIN`) — message kept
   **verbatim**, and still evaluated first, so a genuine auth misconfiguration is
   reported exactly as it is today.
2. **Tenant scope** (`ZSCALER_CUSTOMER_ID`, `ZCELL_CUSTOMER_ID`) — new message:

```
ZSCALER_CUSTOMER_ID is required for zpa tools. It is the tenant/customer ID, not a
OneAPI credential. Set it in the environment or .env file. OneAPI authentication
itself is unaffected — if other products answer successfully, your credentials are
fine. If this tenant is not entitled to zpa, the value may not exist at all.
```

Three properties that matter: it doesn't call a tenant ID a credential, it names
the product family, and it flags that a nonexistent value can mean *not entitled*
rather than *misconfigured* — so nobody hunts for an ID that does not exist.

Also in this change:

- The docstring made the same conflation, listing both customer IDs under
  "Credentials". It now separates credentials from tenant scope.
- The blank/missing check is extracted into a small `_absent()` helper (both
  call sites need it; it preserves declaration order).

**There is no behavioural change.** The same calls still fail, with the same
`RuntimeError` type, at the same point in the same order. Only the diagnostics
change.

### Precedent in-tree

`src/zscaler_mcp/tools/zms/_common.py:29-36` already handles this correctly for
ZMS and words it the right way:

```python
raise RuntimeError(
    "ZSCALER_CUSTOMER_ID is required for ZMS tools. Set it in the server "
    "environment (the tenant/customer ID)."
)
```

So this PR is really "make `client.py` as accurate as `tools/zms/_common.py`
already is" — before it, the two sites disagreed about what `ZSCALER_CUSTOMER_ID`
*is*.

## Has your change been tested?

Yes. New `tests/test_client.py` (22 tests) — the factory had no dedicated test
module before this.

- `_absent()`: missing / `None` / blank / empty, and declaration order preserved.
- **Credentials still reported as credentials** — per-variable, plus blank-counts-
  as-missing, plus an ordering test asserting that when a credential *and* the ZPA
  scope are both absent the operator is told about the credential (and the scope
  variable is *not* mentioned).
- **Tenant scope is not called a credential** — the actual regression guard: for
  ZPA and ZCell, asserts `"missing OneAPI credentials"` is absent from the message
  while `tenant/customer ID`, `not a OneAPI credential`, the service name, and
  `not entitled` are all present.
- **Scope is per-product, not global** — parametrized over `zia`, `zdx`, `zcc`,
  `ztw`, `zid`, `zins`, `zms` and `None`: all construct fine with no customer ID
  set, and neither `customerId` nor `zcellCustomerId` leaks into the SDK config.
  This guards the "reads as OneAPI-wide when it is per-product" half of the bug.
- **The two IDs are independent** — a set `ZSCALER_CUSTOMER_ID` does not satisfy
  ZCell, per the `zcellCustomerId` note at `client.py:53-57`.
- **Happy paths** — ZPA and ZCell construct and pass the right key through to the
  SDK config.
- **Unchanged neighbour** — the secret/private-key check still raises `ValueError`.

The tests blank the factory's whole env surface and stub `load_dotenv`, so a
developer's real `.env` can't leak in and mask a missing-value assertion.

Full suite, lint and the docs gate (Python 3.13, `uv`):

```
$ pytest tests/ --ignore=tests/e2e -q
436 passed in 4.16s

$ ruff check . --select I
All checks passed!

$ ruff check .
All checks passed!

$ zscaler-mcp --check-docs
Docs are in sync with the live tool inventory.
```

`ruff format` is clean on both files. I also rendered all three messages against
the real code path to check they read well as prose, not just that they contain
the right substrings.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented and stable APIs.

Documentation note: the affected docstring is updated in this PR. I grepped
`*.md` / `*.rst` for these variable names and found no prose doc that describes
them as credentials, so there is nothing else to correct; `--check-docs` confirms
the generated regions are in sync.

## Relationship to #97

Independent and non-conflicting — #97 touches `security/entitlements.py` +
`tests/test_entitlements.py`, this touches `client.py` + a new `tests/test_client.py`.
Both branch from `master`, so they can merge in either order. They were found in
the same investigation, which is the only thing they share.
