### PR TITLE
fix: ZPA pagination across 16 list tools, entitlement prd mapping gaps, and tenant-scope error wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Zscaler Integrations MCP Server Changelog
 
+## 0.15.2 (August 13, 2026)
+
+### Notes
+
+- Python Versions: **v3.11, v3.12, v3.13, v3.14**
+
+### Bug Fixes
+
+- [Issue #96](https://github.com/zscaler/zscaler-mcp-server/issues/96) - **ZPA list tools can now paginate past the first 20 results.** The ZPA API paginates (default 20 rows, max 500) and 16 list tools had no way to request more, so large tenants silently saw a truncated view — including policy rules, where evaluation order matters. All five policy-rule families (access, timeout, forwarding, isolation, app protection) plus 11 further ZPA list tools (BA certificates, PRA credentials/portals, provisioning keys, SAML/SCIM attributes, SCIM groups, app-protection/posture profiles, trusted networks, enrollment certificates) now accept `page` and `page_size`, and the policy-rule tools also accept `search`.
+
+- [Issue #95](https://github.com/zscaler/zscaler-mcp-server/issues/95) - **The entitlement filter no longer strips working Cloud & Branch Connector, ZIdentity, and Z-Insights tools.** ZIdentity emits `CLOUD_CONNECTOR`, `ZIAM`, and `ZINSIGHTS` in the token's `service-info` claim — values the filter did not recognize, so it removed `ztw_*` / `zid_*` / `zins_*` tools the tenant was genuinely entitled to. The three values are now mapped (pinned against a live token), and any unmapped product value is named in a startup warning so a future mapping gap is visible instead of masquerading as a missing entitlement.
+
+- [Issue #98](https://github.com/zscaler/zscaler-mcp-server/issues/98) - **A missing customer ID is no longer reported as a missing credential.** `ZSCALER_CUSTOMER_ID` (ZPA) and `ZCELL_CUSTOMER_ID` (ZCell) are tenant-scope identifiers, but the error called them "missing OneAPI credentials", sending operators to re-check a client ID / secret that was working fine. The error now names the product family that needs the value, states that authentication itself is unaffected, and notes that the value may not exist on a tenant not entitled to that product.
+
 ## 0.15.1 (August 12, 2026)
 
 ### Notes

--- a/docsrc/guides/release-notes.rst
+++ b/docsrc/guides/release-notes.rst
@@ -6,6 +6,20 @@ Release Notes
 Zscaler Integrations MCP Server Changelog
 ------------------------------------------
 
+## 0.15.2 (August 13, 2026)
+
+### Notes
+
+- Python Versions: **v3.11, v3.12, v3.13, v3.14**
+
+### Bug Fixes
+
+`Issue #96 <https://github.com/zscaler/zscaler-mcp-server/issues/96>`_ - **ZPA list tools can now paginate past the first 20 results.** The ZPA API paginates (default 20 rows, max 500) and 16 list tools had no way to request more, so large tenants silently saw a truncated view — including policy rules, where evaluation order matters. All five policy-rule families (access, timeout, forwarding, isolation, app protection) plus 11 further ZPA list tools (BA certificates, PRA credentials/portals, provisioning keys, SAML/SCIM attributes, SCIM groups, app-protection/posture profiles, trusted networks, enrollment certificates) now accept ``page`` and ``page_size``, and the policy-rule tools also accept ``search``.
+
+`Issue #95 <https://github.com/zscaler/zscaler-mcp-server/issues/95>`_ - **The entitlement filter no longer strips working Cloud & Branch Connector, ZIdentity, and Z-Insights tools.** ZIdentity emits ``CLOUD_CONNECTOR``, ``ZIAM``, and ``ZINSIGHTS`` in the token's ``service-info`` claim — values the filter did not recognize, so it removed ``ztw_*`` / ``zid_*`` / ``zins_*`` tools the tenant was genuinely entitled to. The three values are now mapped (pinned against a live token), and any unmapped product value is named in a startup warning so a future mapping gap is visible instead of masquerading as a missing entitlement.
+
+`Issue #98 <https://github.com/zscaler/zscaler-mcp-server/issues/98>`_ - **A missing customer ID is no longer reported as a missing credential.** ``ZSCALER_CUSTOMER_ID`` (ZPA) and ``ZCELL_CUSTOMER_ID`` (ZCell) are tenant-scope identifiers, but the error called them "missing OneAPI credentials", sending operators to re-check a client ID / secret that was working fine. The error now names the product family that needs the value, states that authentication itself is unaffected, and notes that the value may not exist on a tenant not entitled to that product.
+
 ## 0.15.1 (August 12, 2026)
 
 ### Notes

--- a/src/zscaler_mcp/client.py
+++ b/src/zscaler_mcp/client.py
@@ -59,17 +59,35 @@ def get_zscaler_client(*, service: str | None = None):
     cloud = os.getenv("ZSCALER_CLOUD")
     user_agent_comment = os.getenv("ZSCALER_MCP_USER_AGENT_COMMENT")
 
-    required = {"ZSCALER_CLIENT_ID": client_id, "ZSCALER_VANITY_DOMAIN": vanity_domain}
+    # Credentials and tenant-scope identifiers are checked separately because
+    # they fail differently (issue #98): a missing credential breaks OneAPI auth
+    # for everything, while a missing customer ID only scopes out one product
+    # family — and on a tenant not entitled to that product the value may not
+    # exist at all. Reporting a scope ID as a "missing credential" sends the
+    # operator to re-check a client ID / secret that is working fine.
+    credentials = {"ZSCALER_CLIENT_ID": client_id, "ZSCALER_VANITY_DOMAIN": vanity_domain}
+    scope_ids: dict[str, str | None] = {}
     if service == "zpa":
-        required["ZSCALER_CUSTOMER_ID"] = customer_id
+        scope_ids["ZSCALER_CUSTOMER_ID"] = customer_id
     if service == "zcell":
-        required["ZCELL_CUSTOMER_ID"] = zcell_customer_id
+        scope_ids["ZCELL_CUSTOMER_ID"] = zcell_customer_id
 
-    missing = [name for name, value in required.items() if not (value and value.strip())]
-    if missing:
+    def _absent(values: dict[str, str | None]) -> list[str]:
+        return [name for name, value in values.items() if not (value and value.strip())]
+
+    missing_credentials = _absent(credentials)
+    if missing_credentials:
         raise RuntimeError(
             "Zscaler SDK failed to initialize due to missing OneAPI credentials: "
-            f"{missing}. Set them in the environment or .env file."
+            f"{missing_credentials}. Set them in the environment or .env file."
+        )
+    missing_scope = _absent(scope_ids)
+    if missing_scope:
+        raise RuntimeError(
+            f"{missing_scope[0]} is required for {service} tools. Set it in the "
+            "environment or .env file (the tenant/customer ID, not an OneAPI "
+            f"credential — authentication itself is unaffected). If your tenant "
+            f"is not entitled to {service}, this value may not exist."
         )
     if not client_secret and not private_key:
         raise ValueError(

--- a/src/zscaler_mcp/security/entitlements.py
+++ b/src/zscaler_mcp/security/entitlements.py
@@ -61,13 +61,22 @@ PRD_TO_SERVICE: dict[str, str] = {
     "ZDX": "zdx",
     "ZCC": "zcc",
     "ZTW": "ztw",
+    # Canonical `prd` value ZIdentity emits for Cloud & Branch Connector,
+    # pinned against a live OneAPI token (issue #95).
+    "CLOUD_CONNECTOR": "ztw",
     "ZIDENTITY": "zid",
     "ZID": "zid",
     "IDENTITY": "zid",
+    # Canonical `prd` value ZIdentity emits for ZIdentity itself (Identity &
+    # Access Management), pinned against a live OneAPI token (issue #95).
+    "ZIAM": "zid",
     "ZEASM": "zeasm",
     "EASM": "zeasm",
     "ZINS": "zins",
     "INSIGHTS": "zins",
+    # Canonical `prd` value ZIdentity emits for Z-Insights, pinned against a
+    # live OneAPI token (issue #95).
+    "ZINSIGHTS": "zins",
     "ZMS": "zms",
     # ZCell (Zscaler Cellular). The exact `prd` claim value ZIdentity emits for
     # Cellular is not yet confirmed against a live token; map the likely variants
@@ -109,9 +118,14 @@ def extract_entitled_services(payload: dict) -> Set[str]:
 
     Reads ``service-info`` from the payload, lifts each ``prd`` value, and maps
     known product codes to internal service identifiers (``zia`` / ``zpa`` /
-    ...). Unknown product codes are silently skipped.
+    ...). Product codes with no MCP service (RISK360, ZGUARD, BI, ...) are
+    skipped, but every skipped value is named in a WARN line: an unmapped value
+    for a product this server DOES serve means the filter is about to remove
+    working tools (the class of bug in issue #95), and without the log that is
+    indistinguishable from a genuine entitlement gap.
     """
     services: Set[str] = set()
+    unmapped: list[str] = []
 
     service_info = payload.get("service-info") or payload.get("serviceInfo")
     if not isinstance(service_info, list):
@@ -126,6 +140,17 @@ def extract_entitled_services(payload: dict) -> Set[str]:
         mapped = PRD_TO_SERVICE.get(prd.strip().upper())
         if mapped:
             services.add(mapped)
+        else:
+            unmapped.append(prd.strip())
+
+    if unmapped:
+        logger.warning(
+            "entitlement filter: token carries prd values with no known service "
+            "mapping, ignored: %s. If one of these corresponds to a product this "
+            "server provides tools for, its tools are being removed by a mapping "
+            "gap, not a missing entitlement — please report it.",
+            sorted(set(unmapped)),
+        )
 
     return services
 

--- a/src/zscaler_mcp/tools/zpa/_policy_common.py
+++ b/src/zscaler_mcp/tools/zpa/_policy_common.py
@@ -39,6 +39,23 @@ __all__ = [
 class ListRulesInput(BaseModel):
     """Inputs for listing a ZPA policy-rule family."""
 
+    search: Annotated[
+        Optional[str],
+        Field(default=None, description="Search string matched server-side against rule fields."),
+    ] = None
+    page: Annotated[Optional[int], Field(default=None, ge=1, description="Page number.")] = None
+    page_size: Annotated[
+        Optional[int],
+        Field(
+            default=None,
+            ge=1,
+            le=500,
+            description=(
+                "Items per page (API default 20, max 500). The API paginates: without "
+                "`page`/`page_size` only the first 20 rules are returned."
+            ),
+        ),
+    ] = None
     microtenant_id: Annotated[
         Optional[str], Field(default=None, description="Microtenant ID for scoping.")
     ] = None
@@ -85,7 +102,17 @@ def _opt_str(value: Any) -> Optional[str]:
 
 def list_rules(policy_type: str, args: ListRulesInput) -> list[dict[str, Any]]:
     client = get_zscaler_client(service="zpa")
+    # The endpoint paginates (default 20 rows, max 500) and the SDK does not
+    # auto-page, so these must reach the API or callers silently see only the
+    # first 20 rules (issue #96). Same passthrough shape as segment_groups; the
+    # SDK's request executor owns the page_size -> pagesize wire spelling.
     qp: dict[str, Any] = {}
+    if args.search:
+        qp["search"] = args.search
+    if args.page is not None:
+        qp["page"] = str(args.page)
+    if args.page_size is not None:
+        qp["page_size"] = str(args.page_size)
     if args.microtenant_id:
         qp["microtenant_id"] = args.microtenant_id
     rules, _, err = client.zpa.policies.list_rules(policy_type, query_params=qp)

--- a/src/zscaler_mcp/tools/zpa/ba_certificate.py
+++ b/src/zscaler_mcp/tools/zpa/ba_certificate.py
@@ -31,6 +31,11 @@ class ListBaCertsInput(BaseModel):
     search: Annotated[
         Optional[str], Field(default=None, description="Server-side substring match on `name`.")
     ] = None
+    page: Annotated[Optional[int], Field(default=None, ge=1, description="Page number.")] = None
+    page_size: Annotated[
+        Optional[int],
+        Field(default=None, ge=1, le=500, description="Items per page (API default 20, max 500)."),
+    ] = None
     microtenant_id: Annotated[
         Optional[str], Field(default=None, description="Microtenant ID for scoping.")
     ] = None
@@ -88,6 +93,10 @@ def zpa_list_ba_certificates(args: ListBaCertsInput) -> list[dict[str, Any]]:
     qp: dict[str, Any] = {}
     if args.search:
         qp["search"] = args.search
+    if args.page is not None:
+        qp["page"] = str(args.page)
+    if args.page_size is not None:
+        qp["page_size"] = str(args.page_size)
     if args.microtenant_id:
         qp["microtenant_id"] = args.microtenant_id
     certs, _, err = client.zpa.certificates.list_issued_certificates(query_params=qp)

--- a/src/zscaler_mcp/tools/zpa/get_app_protection_profile.py
+++ b/src/zscaler_mcp/tools/zpa/get_app_protection_profile.py
@@ -22,6 +22,11 @@ class AppProtectionProfileInput(BaseModel):
     name: Annotated[
         Optional[str], Field(default=None, description="Optional exact name to filter by.")
     ] = None
+    page: Annotated[Optional[int], Field(default=None, ge=1, description="Page number.")] = None
+    page_size: Annotated[
+        Optional[int],
+        Field(default=None, ge=1, le=500, description="Items per page (API default 20, max 500)."),
+    ] = None
 
 
 @tool(
@@ -36,6 +41,10 @@ def get_zpa_app_protection_profile(args: AppProtectionProfileInput) -> list[dict
     """List ZPA App Protection (inspection) profiles, or filter by name (read-only)."""
     client = get_zscaler_client(service="zpa")
     qp = {"search": args.name} if args.name else {}
+    if args.page is not None:
+        qp["page"] = str(args.page)
+    if args.page_size is not None:
+        qp["page_size"] = str(args.page_size)
     profiles, _, err = client.zpa.app_protection.list_profiles(query_params=qp)
     if err:
         raise RuntimeError(f"Failed to list app protection profiles: {err}")

--- a/src/zscaler_mcp/tools/zpa/get_enrollment_certificate.py
+++ b/src/zscaler_mcp/tools/zpa/get_enrollment_certificate.py
@@ -36,6 +36,11 @@ class EnrollmentCertInput(BaseModel):
     search: Annotated[
         Optional[str], Field(default=None, description="Server-side substring match on `name`.")
     ] = None
+    page: Annotated[Optional[int], Field(default=None, ge=1, description="Page number.")] = None
+    page_size: Annotated[
+        Optional[int],
+        Field(default=None, ge=1, le=500, description="Items per page (API default 20, max 500)."),
+    ] = None
 
 
 @tool(
@@ -67,6 +72,10 @@ def get_zpa_enrollment_certificate(args: EnrollmentCertInput) -> list[dict[str, 
         return shape_many([cert.as_dict()])
 
     qp: dict[str, Any] = {"search": args.search} if args.search else {}
+    if args.page is not None:
+        qp["page"] = str(args.page)
+    if args.page_size is not None:
+        qp["page_size"] = str(args.page_size)
     certs, _, err = api.list_enrolment(query_params=qp or None)
     if err:
         raise RuntimeError(f"Failed to list enrollment certificates: {err}")

--- a/src/zscaler_mcp/tools/zpa/get_posture_profiles.py
+++ b/src/zscaler_mcp/tools/zpa/get_posture_profiles.py
@@ -25,6 +25,11 @@ class PostureProfileInput(BaseModel):
     name: Annotated[
         Optional[str], Field(default=None, description="Exact posture profile name to match.")
     ] = None
+    page: Annotated[Optional[int], Field(default=None, ge=1, description="Page number.")] = None
+    page_size: Annotated[
+        Optional[int],
+        Field(default=None, ge=1, le=500, description="Items per page (API default 20, max 500)."),
+    ] = None
 
 
 @tool(
@@ -47,6 +52,10 @@ def get_zpa_posture_profile(args: PostureProfileInput) -> list[dict[str, Any]]:
         return shape_many([profile.as_dict()])
 
     qp = {"search": args.name} if args.name else {}
+    if args.page is not None:
+        qp["page"] = str(args.page)
+    if args.page_size is not None:
+        qp["page_size"] = str(args.page_size)
     profiles, _, err = api.list_posture_profiles(query_params=qp)
     if err:
         raise RuntimeError(f"Failed to list posture profiles: {err}")

--- a/src/zscaler_mcp/tools/zpa/get_saml_attributes.py
+++ b/src/zscaler_mcp/tools/zpa/get_saml_attributes.py
@@ -28,6 +28,11 @@ class SamlAttributeInput(BaseModel):
     search: Annotated[
         Optional[str], Field(default=None, description="Server-side substring match.")
     ] = None
+    page: Annotated[Optional[int], Field(default=None, ge=1, description="Page number.")] = None
+    page_size: Annotated[
+        Optional[int],
+        Field(default=None, ge=1, le=500, description="Items per page (API default 20, max 500)."),
+    ] = None
 
 
 @tool(
@@ -44,6 +49,10 @@ def get_zpa_saml_attribute(args: SamlAttributeInput) -> list[dict[str, Any]]:
     qp: dict[str, Any] = {}
     if args.search:
         qp["search"] = args.search
+    if args.page is not None:
+        qp["page"] = str(args.page)
+    if args.page_size is not None:
+        qp["page_size"] = str(args.page_size)
     if args.idp_name:
         idp_id = resolve_idp_id(client, args.idp_name)
         attrs, _, err = client.zpa.saml_attributes.list_saml_attributes_by_idp(

--- a/src/zscaler_mcp/tools/zpa/get_scim_attributes.py
+++ b/src/zscaler_mcp/tools/zpa/get_scim_attributes.py
@@ -29,6 +29,11 @@ class ScimAttributeInput(BaseModel):
     search: Annotated[
         Optional[str], Field(default=None, description="Server-side substring match.")
     ] = None
+    page: Annotated[Optional[int], Field(default=None, ge=1, description="Page number.")] = None
+    page_size: Annotated[
+        Optional[int],
+        Field(default=None, ge=1, le=500, description="Items per page (API default 20, max 500)."),
+    ] = None
 
 
 @tool(
@@ -48,6 +53,10 @@ def get_zpa_scim_attribute(args: ScimAttributeInput) -> list[dict[str, Any]]:
     qp: dict[str, Any] = {}
     if args.search:
         qp["search"] = args.search
+    if args.page is not None:
+        qp["page"] = str(args.page)
+    if args.page_size is not None:
+        qp["page_size"] = str(args.page_size)
     if args.attribute_id:
         attr, _, err = client.zpa.scim_attributes.get_scim_attribute(
             idp_id=idp_id, attribute_id=args.attribute_id, query_params=qp

--- a/src/zscaler_mcp/tools/zpa/get_scim_groups.py
+++ b/src/zscaler_mcp/tools/zpa/get_scim_groups.py
@@ -31,6 +31,11 @@ class ScimGroupInput(BaseModel):
     search: Annotated[
         Optional[str], Field(default=None, description="Server-side substring match.")
     ] = None
+    page: Annotated[Optional[int], Field(default=None, ge=1, description="Page number.")] = None
+    page_size: Annotated[
+        Optional[int],
+        Field(default=None, ge=1, le=500, description="Items per page (API default 20, max 500)."),
+    ] = None
 
 
 @tool(
@@ -47,6 +52,10 @@ def get_zpa_scim_group(args: ScimGroupInput) -> list[dict[str, Any]]:
     qp: dict[str, Any] = {}
     if args.search:
         qp["search"] = args.search
+    if args.page is not None:
+        qp["page"] = str(args.page)
+    if args.page_size is not None:
+        qp["page_size"] = str(args.page_size)
 
     if args.scim_group_id:
         group, _, err = client.zpa.scim_groups.get_scim_group(args.scim_group_id, query_params=qp)

--- a/src/zscaler_mcp/tools/zpa/get_trusted_networks.py
+++ b/src/zscaler_mcp/tools/zpa/get_trusted_networks.py
@@ -25,6 +25,11 @@ class TrustedNetworkInput(BaseModel):
     name: Annotated[
         Optional[str], Field(default=None, description="Exact trusted network name to match.")
     ] = None
+    page: Annotated[Optional[int], Field(default=None, ge=1, description="Page number.")] = None
+    page_size: Annotated[
+        Optional[int],
+        Field(default=None, ge=1, le=500, description="Items per page (API default 20, max 500)."),
+    ] = None
 
 
 @tool(
@@ -47,6 +52,10 @@ def get_zpa_trusted_network(args: TrustedNetworkInput) -> list[dict[str, Any]]:
         return shape_many([network.as_dict()])
 
     qp = {"search": args.name} if args.name else {}
+    if args.page is not None:
+        qp["page"] = str(args.page)
+    if args.page_size is not None:
+        qp["page_size"] = str(args.page_size)
     networks, _, err = api.list_trusted_networks(query_params=qp)
     if err:
         raise RuntimeError(f"Failed to list trusted networks: {err}")

--- a/src/zscaler_mcp/tools/zpa/pra_credential.py
+++ b/src/zscaler_mcp/tools/zpa/pra_credential.py
@@ -35,6 +35,11 @@ class ListCredentialsInput(BaseModel):
     search: Annotated[
         Optional[str], Field(default=None, description="Server-side substring match on `name`.")
     ] = None
+    page: Annotated[Optional[int], Field(default=None, ge=1, description="Page number.")] = None
+    page_size: Annotated[
+        Optional[int],
+        Field(default=None, ge=1, le=500, description="Items per page (API default 20, max 500)."),
+    ] = None
     microtenant_id: Annotated[
         Optional[str], Field(default=None, description="Microtenant ID for scoping.")
     ] = None
@@ -177,6 +182,10 @@ def zpa_list_pra_credentials(args: ListCredentialsInput) -> list[dict[str, Any]]
     qp: dict[str, Any] = {}
     if args.search:
         qp["search"] = args.search
+    if args.page is not None:
+        qp["page"] = str(args.page)
+    if args.page_size is not None:
+        qp["page_size"] = str(args.page_size)
     if args.microtenant_id:
         qp["microtenant_id"] = args.microtenant_id
     creds, _, err = client.zpa.pra_credential.list_credentials(query_params=qp)

--- a/src/zscaler_mcp/tools/zpa/pra_portal.py
+++ b/src/zscaler_mcp/tools/zpa/pra_portal.py
@@ -29,6 +29,11 @@ class ListPortalsInput(BaseModel):
     search: Annotated[
         Optional[str], Field(default=None, description="Server-side substring match on `name`.")
     ] = None
+    page: Annotated[Optional[int], Field(default=None, ge=1, description="Page number.")] = None
+    page_size: Annotated[
+        Optional[int],
+        Field(default=None, ge=1, le=500, description="Items per page (API default 20, max 500)."),
+    ] = None
     microtenant_id: Annotated[
         Optional[str], Field(default=None, description="Microtenant ID for scoping.")
     ] = None
@@ -138,6 +143,10 @@ def zpa_list_pra_portals(args: ListPortalsInput) -> list[dict[str, Any]]:
     qp: dict[str, Any] = {}
     if args.search:
         qp["search"] = args.search
+    if args.page is not None:
+        qp["page"] = str(args.page)
+    if args.page_size is not None:
+        qp["page_size"] = str(args.page_size)
     if args.microtenant_id:
         qp["microtenant_id"] = args.microtenant_id
     portals, _, err = client.zpa.pra_portal.list_portals(query_params=qp)

--- a/src/zscaler_mcp/tools/zpa/provisioning_key.py
+++ b/src/zscaler_mcp/tools/zpa/provisioning_key.py
@@ -30,6 +30,11 @@ class ListKeysInput(BaseModel):
     search: Annotated[
         Optional[str], Field(default=None, description="Server-side substring match on `name`.")
     ] = None
+    page: Annotated[Optional[int], Field(default=None, ge=1, description="Page number.")] = None
+    page_size: Annotated[
+        Optional[int],
+        Field(default=None, ge=1, le=500, description="Items per page (API default 20, max 500)."),
+    ] = None
     microtenant_id: Annotated[
         Optional[str], Field(default=None, description="Microtenant ID for scoping.")
     ] = None
@@ -121,6 +126,10 @@ def zpa_list_provisioning_keys(args: ListKeysInput) -> list[dict[str, Any]]:
     qp: dict[str, Any] = {}
     if args.search:
         qp["search"] = args.search
+    if args.page is not None:
+        qp["page"] = str(args.page)
+    if args.page_size is not None:
+        qp["page_size"] = str(args.page_size)
     if args.microtenant_id:
         qp["microtenant_id"] = args.microtenant_id
     keys, _, err = client.zpa.provisioning.list_provisioning_keys(

--- a/tests/test_client_scope_errors.py
+++ b/tests/test_client_scope_errors.py
@@ -1,0 +1,76 @@
+"""Tenant-scope IDs are not credentials — the errors must not conflate them.
+
+Issue #98: a missing ``ZSCALER_CUSTOMER_ID`` (ZPA) or ``ZCELL_CUSTOMER_ID``
+(ZCell) was reported as "missing OneAPI credentials", sending operators to
+re-check a client ID / secret that was working fine, and hiding that a missing
+customer ID can mean "tenant not entitled to this product" rather than
+"misconfigured".
+
+Env vars are pinned to empty strings (not deleted) so ``load_dotenv()`` — which
+never overrides existing variables — cannot re-populate them from a local .env.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from zscaler_mcp.client import get_zscaler_client
+
+_ALL_VARS = [
+    "ZSCALER_CLIENT_ID",
+    "ZSCALER_CLIENT_SECRET",
+    "ZSCALER_PRIVATE_KEY",
+    "ZSCALER_VANITY_DOMAIN",
+    "ZSCALER_CUSTOMER_ID",
+    "ZCELL_CUSTOMER_ID",
+]
+
+
+def _pin_env(monkeypatch, **present: str) -> None:
+    for name in _ALL_VARS:
+        monkeypatch.setenv(name, present.get(name, ""))
+
+
+def test_missing_credentials_still_reported_as_credentials(monkeypatch):
+    _pin_env(monkeypatch)
+    with pytest.raises(RuntimeError, match="OneAPI credentials"):
+        get_zscaler_client(service="zia")
+
+
+def test_missing_zpa_customer_id_is_not_called_a_credential(monkeypatch):
+    _pin_env(monkeypatch, ZSCALER_CLIENT_ID="id", ZSCALER_VANITY_DOMAIN="acme")
+    with pytest.raises(RuntimeError) as exc:
+        get_zscaler_client(service="zpa")
+    message = str(exc.value)
+    assert "ZSCALER_CUSTOMER_ID" in message
+    assert "zpa" in message
+    assert "not an OneAPI credential" in message
+    assert "entitled" in message
+    assert "missing OneAPI credentials" not in message
+
+
+def test_missing_zcell_customer_id_is_not_called_a_credential(monkeypatch):
+    _pin_env(monkeypatch, ZSCALER_CLIENT_ID="id", ZSCALER_VANITY_DOMAIN="acme")
+    with pytest.raises(RuntimeError) as exc:
+        get_zscaler_client(service="zcell")
+    message = str(exc.value)
+    assert "ZCELL_CUSTOMER_ID" in message
+    assert "zcell" in message
+    assert "not an OneAPI credential" in message
+    assert "missing OneAPI credentials" not in message
+
+
+def test_missing_credentials_win_over_missing_scope(monkeypatch):
+    # When BOTH are absent the operator should fix credentials first — the
+    # credential error must be the one raised.
+    _pin_env(monkeypatch)
+    with pytest.raises(RuntimeError, match="OneAPI credentials"):
+        get_zscaler_client(service="zpa")
+
+
+def test_scope_ids_not_required_for_other_services(monkeypatch):
+    # zia does not need either customer ID: with creds present the scope check
+    # must not fire (the call proceeds past it to the secret/key check).
+    _pin_env(monkeypatch, ZSCALER_CLIENT_ID="id", ZSCALER_VANITY_DOMAIN="acme")
+    with pytest.raises(ValueError, match="ZSCALER_CLIENT_SECRET or ZSCALER_PRIVATE_KEY"):
+        get_zscaler_client(service="zia")

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -75,6 +75,55 @@ def test_extract_handles_aliases():
     assert extract_entitled_services(payload) == {"zid", "zeasm"}
 
 
+def test_extract_maps_prd_values_a_real_token_emits():
+    """The canonical values pinned against a live ZIdentity token (issue #95).
+
+    ZIdentity emits ``CLOUD_CONNECTOR`` for Cloud & Branch Connector, ``ZIAM``
+    for ZIdentity, and ``ZINSIGHTS`` for Z-Insights — none of which matched the
+    guessed aliases, so the entitlement filter stripped working ztw/zid/zins
+    tools. The payload below mirrors the real token's ``service-info`` shape.
+    """
+    payload = {
+        "service-info": [
+            {"prd": "ZIA"},
+            {"prd": "ZPA"},
+            {"prd": "CLOUD_CONNECTOR"},
+            {"prd": "ZCC"},
+            {"prd": "ZDX"},
+            {"prd": "ZIAM"},
+            {"prd": "ZINSIGHTS"},
+        ]
+    }
+    assert extract_entitled_services(payload) == {
+        "zia",
+        "zpa",
+        "ztw",
+        "zcc",
+        "zdx",
+        "zid",
+        "zins",
+    }
+
+
+def test_extract_warns_naming_unmapped_prd_values(caplog):
+    """A mapping miss must be visible in the log, or it is indistinguishable
+    from a genuine entitlement gap (the diagnosis problem in issue #95)."""
+    payload = {"service-info": [{"prd": "ZIA"}, {"prd": "RISK360"}, {"prd": "ZGUARD"}]}
+    with caplog.at_level("WARNING", logger="zscaler_mcp.security.entitlements"):
+        assert extract_entitled_services(payload) == {"zia"}
+    warning = " ".join(r.getMessage() for r in caplog.records)
+    assert "RISK360" in warning and "ZGUARD" in warning
+    # The mapped product must not be named as unmapped.
+    assert "'ZIA'" not in warning
+
+
+def test_extract_no_warning_when_everything_maps(caplog):
+    payload = {"service-info": [{"prd": "ZIA"}, {"prd": "ZPA"}]}
+    with caplog.at_level("WARNING", logger="zscaler_mcp.security.entitlements"):
+        extract_entitled_services(payload)
+    assert not caplog.records
+
+
 @pytest.mark.parametrize("payload", [{}, {"service-info": "nope"}, {"service-info": [123, "x"]}])
 def test_extract_returns_empty_on_garbage(payload):
     assert extract_entitled_services(payload) == set()

--- a/tests/test_zpa_policy_pagination.py
+++ b/tests/test_zpa_policy_pagination.py
@@ -1,0 +1,127 @@
+"""Pagination reaches the ZPA policy-rules API (issue #96).
+
+The ``/policySet/rules/policyType/{type}`` endpoint paginates (default 20 rows,
+max 500) and the SDK does not auto-page, so ``page`` / ``page_size`` / ``search``
+must travel from the tool inputs to the SDK call — otherwise callers silently
+see only the first 20 rules of a policy whose evaluation order matters.
+
+``ListRulesInput`` is shared by all five policy-rule families (access, timeout,
+forwarding, isolation, app-protection), so exercising the shared helper plus a
+registry sweep of the advertised schemas covers every one of them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from zscaler_mcp.registry import REGISTRY, discover_tools
+from zscaler_mcp.tools.zpa._policy_common import ListRulesInput, list_rules
+
+_POLICY_LIST_TOOLS = [
+    "zpa_list_access_policy_rules",
+    "zpa_list_timeout_policy_rules",
+    "zpa_list_forwarding_policy_rules",
+    "zpa_list_isolation_policy_rules",
+    "zpa_list_app_protection_rules",
+]
+
+# Every other ZPA list-style tool whose SDK method documents page/page_size —
+# the same 20-row truncation applied to all of them (issue #96 sweep).
+# Deliberately absent: the LSS catalogs (static, the API does not paginate),
+# get_zpa_isolation_profile (SDK list_cbi_profiles has no pagination), and
+# get_zpa_app_segments_by_type (SDK documents page_size/search but no page).
+_OTHER_PAGINATED_TOOLS = [
+    "zpa_list_ba_certificates",
+    "zpa_list_pra_credentials",
+    "zpa_list_pra_portals",
+    "zpa_list_provisioning_keys",
+    "get_zpa_saml_attribute",
+    "get_zpa_scim_attribute",
+    "get_zpa_scim_group",
+    "get_zpa_app_protection_profile",
+    "get_zpa_posture_profile",
+    "get_zpa_trusted_network",
+    "get_zpa_enrollment_certificate",
+]
+
+
+class _FakePolicies:
+    def __init__(self) -> None:
+        self.captured: dict[str, Any] | None = None
+
+    def list_rules(self, policy_type: str, query_params: dict[str, Any]):
+        self.captured = {"policy_type": policy_type, **query_params}
+        return [], None, None
+
+
+def _fake_client(policies: _FakePolicies):
+    class _Zpa:
+        pass
+
+    class _Client:
+        pass
+
+    zpa = _Zpa()
+    zpa.policies = policies
+    client = _Client()
+    client.zpa = zpa
+    return client
+
+
+def _call(**kwargs: Any) -> dict[str, Any]:
+    policies = _FakePolicies()
+    with patch(
+        "zscaler_mcp.tools.zpa._policy_common.get_zscaler_client",
+        return_value=_fake_client(policies),
+    ):
+        list_rules("access", ListRulesInput(**kwargs))
+    assert policies.captured is not None
+    return policies.captured
+
+
+def test_pagination_params_reach_the_sdk():
+    captured = _call(page=3, page_size=500, search="Engineering", microtenant_id="mt1")
+    assert captured == {
+        "policy_type": "access",
+        "page": "3",
+        "page_size": "500",
+        "search": "Engineering",
+        "microtenant_id": "mt1",
+    }
+
+
+def test_omitted_params_are_not_sent():
+    # The API's own defaults govern anything the caller leaves unset.
+    assert _call() == {"policy_type": "access"}
+
+
+def test_page_size_is_capped_at_the_api_maximum():
+    with pytest.raises(ValueError):
+        ListRulesInput(page_size=501)
+    with pytest.raises(ValueError):
+        ListRulesInput(page=0)
+
+
+def test_every_policy_family_advertises_pagination():
+    """The shared input model must reach all five families' schemas."""
+    discover_tools()
+    for name in _POLICY_LIST_TOOLS:
+        spec = REGISTRY.get(name)
+        assert spec is not None, f"{name} is not registered"
+        fields = spec.input_model.model_fields
+        for param in ("page", "page_size", "search"):
+            assert param in fields, f"{name} is missing '{param}'"
+
+
+def test_every_other_paginated_zpa_list_tool_advertises_pagination():
+    """The sweep: every ZPA list tool whose SDK method paginates exposes it."""
+    discover_tools()
+    for name in _OTHER_PAGINATED_TOOLS:
+        spec = REGISTRY.get(name)
+        assert spec is not None, f"{name} is not registered"
+        fields = spec.input_model.model_fields
+        for param in ("page", "page_size"):
+            assert param in fields, f"{name} is missing '{param}'"


### PR DESCRIPTION
Closes #95, closes #96, closes #98.

- ZPA pagination (#96): the API paginates (default 20 rows, max 500) and 16 list tools could not request past the first page. The five policy-rule families (access, timeout, forwarding, isolation, app protection) now accept `page`/`page_size`/`search` via the shared ListRulesInput, and 11 further ZPA list tools (BA certificates, PRA credentials/portals, provisioning keys, SAML/SCIM attributes, SCIM groups, app-protection/posture profiles, trusted networks, enrollment certificates) accept `page`/`page_size`. Every added parameter was verified against the SDK's documented query_params; tools whose SDK method does not paginate (LSS catalogs, CBI profiles, segments-by-type `page`) are deliberately unchanged and pinned by a sweep test.

- Entitlement filter (#95): map the prd values ZIdentity actually emits — CLOUD_NNECTOR -> ztw, ZIAM -> zid, ZINSIGHTS -> zins (pinned against a live token) — so entitled tools are no longer stripped at startup, and WARN-log any unmapped prd value so a mapping gap is distinguishable from a genuine entitlement gap.

- Client errors (#98): ZSCALER_CUSTOMER_ID (ZPA) and ZCELL_CUSTOMER_ID (ZCell) are tenant-scope identifiers, not credentials. A missing one now raises its own error naming the product family, stating OneAPI authentication is unaffected, and noting the value may not exist on an unentitled tenant — instead of "missing OneAPI credentials".

Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points.

## Description

Describe your changes in detail through motivation and context. Why is
this change required? What problem does it solve? If it fixes an open
issue, link to the issue using GitHub's closing issues keywords[1].

## Has your change been tested?

Explain how the change has been tested and what you ran to confirm your
change affects other parts of the code. Automated tests are generally
expected and changes without tests should explain why they aren't
required.

## Screenshots (if appropriate)

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
